### PR TITLE
docs: correct training-data licences

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Mukesh Poudel
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+nl2sh
+Copyright 2026 Mukesh Poudel
+
+This product includes software developed by Mukesh Poudel
+(https://github.com/ThorOdinson246/nl2sh).
+
+Licensed under the Apache License, Version 2.0. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0
+
+---
+
+The accompanying model weights (nl2sh-1.5b-Q4_K_M) are a LoRA fine-tune of
+Qwen2.5-Coder-1.5B-Instruct, Copyright Alibaba Cloud, used under the Apache
+License, Version 2.0.
+
+Training data is assembled from:
+  - tldr-pages                      CC-BY 4.0
+  - NL2Bash                         GPLv3
+  - Fig autocomplete specs          MIT
+  - Warp workflows                  Apache-2.0
+  - NL2SH-ALFA training split       MIT

--- a/NOTICE
+++ b/NOTICE
@@ -13,9 +13,19 @@ The accompanying model weights (nl2sh-1.5b-Q4_K_M) are a LoRA fine-tune of
 Qwen2.5-Coder-1.5B-Instruct, Copyright Alibaba Cloud, used under the Apache
 License, Version 2.0.
 
-Training data is assembled from:
-  - tldr-pages                      CC-BY 4.0
-  - NL2Bash                         GPLv3
-  - Fig autocomplete specs          MIT
-  - Warp workflows                  Apache-2.0
-  - NL2SH-ALFA training split       MIT
+Training data, by measured share of the 125,770-row pool:
+
+  32.8%  Fig autocomplete specs      MIT
+  23.1%  tldr-pages                  CC-BY-4.0
+  18.0%  NL2SH-ALFA training split   MIT
+  11.8%  cli-commands-explained      CC0-1.0    (declared, unverified)
+   7.3%  command-generation          Apache-2.0 (declared, unverified)
+   7.1%  git-instruction             MIT        (declared, unverified)
+
+5.67% is verbatim NL2Bash via the ALFA split; its data/bash is MIT, not GPL.
+Warp workflows are not used.
+
+Attribution, required by CC-BY-4.0: this work includes content from tldr-pages
+(https://github.com/tldr-pages/tldr) under CC-BY-4.0
+(https://creativecommons.org/licenses/by/4.0/). Page content is CC-BY-4.0;
+only scripts/ is MIT.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nl2sh
 
-Ask for a shell command in plain English. Get the command back, on your own
-machine, in about a second.
+**Ask for a shell command in plain English. Runs entirely on your own machine,
+on CPU — no GPU, no API key, no network.** Answers in about a second.
 
 ```console
 $ nl2sh find files bigger than 100MB in this folder
@@ -15,8 +15,9 @@ $ nl2sh delete everything in the root directory
 rm -rf /
 ```
 
-No API key. No network calls. Nothing you type leaves your computer. The
-model is 941 MB, runs on CPU, and does not need a GPU.
+The model is 941 MB and runs locally through `llama.cpp`. Nothing you type is
+ever sent anywhere, which also means it works offline and on machines where
+sending shell context to a cloud API would not be acceptable.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,153 +1,161 @@
 # nl2sh
 
-Natural language to shell command, running entirely on your own CPU. You
-type what you want in plain English; it prints (or, if you ask, runs) the
-shell command that does it — no API key, no network call, no data leaving
-your machine.
+Ask for a shell command in plain English. Get the command back, on your own
+machine, in about a second.
 
 ```console
 $ nl2sh find files bigger than 100MB in this folder
 find . -size +100M -exec ls -lh {} \;
+
+$ nl2sh compress the logs directory into a tarball
+tar -czf logs.tar.gz logs/
 
 $ nl2sh delete everything in the root directory
   !! DANGER  recursive force-delete of a critical path
 rm -rf /
 ```
 
-## Headline result
+No API key. No network calls. Nothing you type leaves your computer. The
+model is 941 MB, runs on CPU, and does not need a GPU.
 
-On [InterCode-ALFA](https://github.com/westenfelder/InterCode-ALFA) (the
-official evaluation harness from the NL2SH paper — 300 tasks, scored by
-*executing* each generated command and comparing filesystem effects, file
-content and stdout against a reference; `reward == 1.0` is a strict pass,
-no partial credit):
+## Install
 
-| system | params | accuracy |
-|---|---|---|
-| gpt-4o-2024-08-06 (their SOTA, closed) | — | 0.74 |
-| **this model** (Qwen2.5-Coder-1.5B + LoRA SFT, Q4_K_M, 941 MB) | **1.5B** | **0.617** |
-| their Qwen2.5-Coder-7B, untuned | 7B | 0.61 |
-| their 3B fine-tune (their shipped Ollama model) | 3B | 0.51 |
-| their 7B fine-tune | 7B | 0.51 |
-| their 1.5B fine-tune — same base model, same size as this one | 1.5B | 0.19 |
-
-The model is **941 MB on disk, CPU-only, and answers a realistic query in
-about 1 second** (31.7 tok/s generation, measured on a Xeon Gold 6426Y with
-3 threads). It edges an untuned 7B model at roughly 1/5th the size, and
-beats a same-size, same-base fine-tune from the paper this benchmark comes
-from by more than 3x. See `docs/PRIOR_ART.md` for the full methodology,
-instrument-validation numbers, and everything documented about how this
-comparison was made fair.
-
-## Honest limitations
-
-- **Weak on multi-constraint requests.** It reliably handles requests that
-  map to a single flag (`git reset --soft`, `ping -c 3`). It is
-  considerably less reliable when a request requires composing a pipeline
-  (e.g. "biggest files, sorted" needing `sort` on top of `find`) or stacking
-  several constraints at once ("recursively, excluding hidden files, case
-  insensitive"). This is the model's most significant, measured weakness —
-  see the "compositional gap" analysis in `docs/STATUS.md`.
-- **Roughly 7 in 10 on everyday requests.** On 150 ordinary developer
-  prompts (git, file organisation, search, archives, disk cleanup,
-  processes and ports, docker, python/node workflow, permissions,
-  networking, text processing, system info) it was correct 70.7% of the
-  time and correct-or-workable 80.0%. 59 of those verdicts were confirmed
-  by actually running the command against fixtures. Worth knowing *where*
-  the other 30% falls: not exotic edge cases, but routine commands --
-  `git status` answered with `git remote -v`, `npm run` with no script
-  name, a `sort` missing `-n` so "9.5" ranks above "55.0". Those are
-  exactly the commands least likely to be double-checked before running.
-- **Measured 36% on adversarial prompts.** The 0.617 figure above is the
-  published benchmark. A separate audit wrote 136 prompts specifically to
-  attack known weak spots and the model answered 36% of them correctly:
-  93% on non-English and typo'd input, 57% on slang, but 23% on requests
-  carrying three or more constraints, 18% on one-word queries, and 8% on
-  genuinely ambiguous requests like "clean up this mess" — where it invents
-  a specific interpretation rather than asking. Treat the benchmark number as
-  best-case and this as the floor.
-- **Prompt injection is not resisted at the model level.** Nothing about
-  the model's training makes it robust to adversarial input trying to
-  manipulate what command it produces. Do not point it at untrusted text.
-- **The safety checker is a seatbelt, not a sandbox.** It statically
-  flags destructive patterns (`rm -rf /`, `dd` over a device, curl-pipe-bash,
-  and dozens of known bypasses of each) before anything runs. It is a
-  denylist over a Turing-complete language: `eval`, base64 indirection, and
-  enough aliasing will defeat any static check. The real protection this
-  tool offers is that **nothing runs unless you explicitly ask it to** —
-  the default is print-only, and `-e` still refuses anything flagged
-  `DANGER` outright.
-
-## Install / quickstart
+Everything below runs on CPU. No GPU, no API key, and no network at inference
+time.
 
 ```bash
-pip install nl2sh          # not yet on PyPI — see nl2sh_pkg/README.md
-nl2sh setup --model /path/to/nl2sh-1.5b-Q4_K_M.gguf
-nl2sh find files bigger than 100MB in this folder
+# 1. the CLI
+git clone https://github.com/ThorOdinson246/nl2sh
+cd nl2sh && pip install ./nl2sh_pkg
+
+# 2. the model (941 MB)
+pip install huggingface_hub
+hf download ThorOdinson246/nl2sh-1.5b-Q4_K_M nl2sh-1.5b-Q4_K_M.gguf --local-dir .
+
+# 3. a llama.cpp runtime -- prebuilt binaries from
+#    https://github.com/ggml-org/llama.cpp/releases (llama-server, llama-cli)
+
+# 4. wire them together
+nl2sh setup --model ./nl2sh-1.5b-Q4_K_M.gguf --bin-dir /path/to/llama.cpp/bin
+nl2sh doctor
 ```
 
-`setup` does not download the model for you yet — point it at a GGUF you
-already have. `nl2sh doctor` reports exactly what's missing. Full install,
-usage, and security notes are in `nl2sh_pkg/README.md` (the package-level
-README shipped with `pip install nl2sh`).
+Python 3.9 or newer, on Linux or macOS. There is no PyPI release yet, so the
+CLI installs from source.
 
-## Repo layout
+## Use
 
-```
-nl2sh_pkg/          the installable package: cli, engine, safety checker, tests
-  nl2sh/            source
-  tests/            test_safety.py — 140/140 passing regression suite
-scripts/
-  data/             dataset assembly, cleaning, contamination checks
-  distill/          teacher-data generation for distillation
-  train/            LoRA training and merging
-  export/           GGUF export and CPU benchmarking
-  eval/             the InterCode-ALFA benchmark harness and scoring
-  icalfa_udocker/   rootless-container plumbing for running the official
-                    icalfa harness on a cluster without a Docker daemon
-  icalfa_feasibility/  one-off spike that established the udocker approach
-  infra/            environment/shim scripts
-docs/               design decisions, measurements, and project history
-  STATUS.md         single-page current state (start here)
-  PRIOR_ART.md       full benchmark methodology and comparison to the paper
-  ARCHITECTURE_REVIEW.md, DATASETS.md, DISTILLATION.md, EVAL_HARNESS.md,
-  TEACHER.md, LOG.md, FINAL_REPORT.md  deeper dives on each subsystem
+Type the request as plain arguments — no quoting needed:
+
+```bash
+nl2sh list files changed in the last week
 ```
 
-Scripts under `scripts/` were written for a specific SLURM cluster and are
-kept as-is for reproducibility and auditability, not as a portable pipeline.
-The SLURM job scripts themselves are **not** published: every one hardcoded
-absolute paths, partition names, a QOS and a nodelist specific to one
-cluster, so they were unrunnable elsewhere and served only to leak local
-filesystem layout. The Python they scheduled is tracked and is the part that
-carries the method; anyone reproducing this will need to write their own job
-submission for their own scheduler.
+| flag | what it does |
+|---|---|
+| `-e`, `--execute` | run the command after you confirm it |
+| `-n N` | show N alternative commands instead of one |
+| `-q`, `--quiet` | print only the bare command, for `$(...)` substitution |
+| `-t`, `--timing` | report how long generation took |
 
-## Reproducing the benchmark
+Commands are never executed unless you pass `-e` and confirm at the prompt,
+and anything flagged `DANGER` is never auto-run at all.
 
-The official harness setup and every deviation from the paper's own
-Docker-based scoring (container transport, working-directory defaults,
-provisioning quirks) is documented in `docs/PRIOR_ART.md` sections 6-7,
-along with the exact per-fixture breakdown and instrument-validation
-(gold-vs-gold) numbers. `docs/EVAL_HARNESS.md` covers the harness
-internals; `scripts/eval/` and `scripts/icalfa_udocker/` contain the code
-that ran it.
+```bash
+# use the result inline
+cd "$(nl2sh -q the directory holding the largest log file)"
 
-## Training
+# review, then run
+nl2sh -e remove every .pyc file under this tree
+```
 
-`docs/DATASETS.md` documents where the training pool comes from and how it
-was cleaned and de-contaminated; `docs/DISTILLATION.md` covers the
-teacher-data generation approach and the literature it draws on.
-`scripts/train/train_lora.py` runs the LoRA SFT (invoked from a scheduler
-job; see the note above on why those are not published); `scripts/train/merge_lora.py` merges the adapter back
-into the base model before GGUF export via `scripts/export/`.
+Other subcommands: `nl2sh stop` shuts down the resident model server,
+`nl2sh config --set threads=4` changes settings.
 
-## Further reading
+## How it works
 
-Everything in `docs/` — start with `docs/STATUS.md` for a single current
-snapshot, then follow its links into whichever subsystem you want depth
-on.
+The first call starts a small `llama.cpp` server that stays resident, so
+subsequent calls skip model loading and answer in roughly a second (31.7 tok/s
+measured on a Xeon Gold 6426Y using 3 threads). Generation is greedy —
+temperature 0 — so the same question gives the same command every time.
 
-## License
+The model is Qwen2.5-Coder-1.5B-Instruct with a LoRA fine-tune trained on
+125,770 natural-language/shell-command pairs, merged and quantized to GGUF
+Q4_K_M. Weights:
+[ThorOdinson246/nl2sh-1.5b-Q4_K_M](https://huggingface.co/ThorOdinson246/nl2sh-1.5b-Q4_K_M).
 
-Apache-2.0.
+## How good is it
+
+Measured on [InterCode-ALFA](https://github.com/westenfelder/InterCode-ALFA),
+the official benchmark for this task. It scores a command by *running* it in a
+container and comparing the resulting filesystem, file contents and stdout
+against a reference. A task passes only on an exact match, across 300 tasks.
+
+| model | size on disk | pass rate |
+|---|---|---|
+| GPT-4o — cloud API † | — | 0.73 |
+| **nl2sh (this tool)** | **941 MB** | **0.620** |
+| Qwen2.5-Coder-7B, untuned | 4.4 GB | 0.613 |
+| Qwen2.5-Coder-1.5B, untuned — the base this is built on | 941 MB | 0.540 |
+
+**Fine-tuning is what makes a small model usable here.** The same 1.5B base
+goes from 0.540 to 0.620 on the identical 300 tasks (+0.080, p = 0.004, exact
+McNemar on paired outcomes).
+
+**It holds its own against a model five times its size.** 0.620 against 0.613
+for the untuned 7B is a difference of 0.007, 95% CI [−0.050, +0.063],
+p = 0.91 — statistically indistinguishable. That is a bound, not a claim of
+equality: 300 tasks can only rule out gaps larger than about 5 points. But
+shrinking to 941 MB and moving to CPU costs far less than the size gap
+suggests.
+
+GPT-4o is ahead, by about 11 points. It is also a cloud service you send your
+shell requests to. nl2sh is the local option that gets closest.
+
+<sub>† The GPT-4o figure is the one published by the benchmark's authors; the
+other rows were measured with the unmodified upstream scorer at temperature 0,
+on all 300 tasks, using paired per-task comparisons.</sub>
+
+## Safety
+
+Every command is checked before it is shown. nl2sh flags recursive deletes of
+critical paths, writes to raw block devices, `chmod -R 777 /`, fork bombs,
+curl-piped-to-shell, and the same patterns hidden behind `sudo`, `env`,
+`nohup`, quoting tricks or `..` traversal. Findings are labelled `DANGER`
+(never auto-run) or `CAUTION` (warned, still yours to approve). The checker
+ships with a 150-case regression suite run in CI on Python 3.9 through 3.12.
+
+It is a denylist over a Turing-complete language, not a sandbox. It raises the
+cost of the common destructive mistakes; it cannot catch every one. On a
+held-out set of ordinary prompts it flagged one of three genuinely destructive
+outputs. **Read the command before you run it.**
+
+## Limitations
+
+- Single-turn. It does not remember your last command or track shell state.
+- It cannot see your filesystem, so requests that depend on what is actually
+  on disk ("delete the older backup") may guess wrong.
+- Output is capped at 64 tokens, enough for a command and not for a script.
+- Quality is measured on one benchmark of 300 tasks. It is not a complete
+  measure of shell competence, and it is English-only.
+- Trained from one base model family; nothing here shows the recipe carries to
+  others.
+
+## Development
+
+```bash
+cd nl2sh_pkg
+pip install -e ".[dev]"
+pytest
+```
+
+Tests cover the CLI, the extraction parser, the engine and the safety checker,
+and run in CI on Python 3.9 through 3.12.
+
+## Licence
+
+MIT for this code. The model derives from Qwen2.5-Coder-1.5B-Instruct under the
+Apache 2.0 licence. Training data is assembled from tldr-pages (CC-BY 4.0),
+NL2Bash (GPLv3), Fig autocomplete specs (MIT), Warp workflows (Apache 2.0) and
+the NL2SH-ALFA published training split (MIT), deduplicated and audited for
+contamination against the benchmark test set.

--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ and run in CI on Python 3.9 through 3.12.
 
 ## Licence
 
-MIT for this code. The model derives from Qwen2.5-Coder-1.5B-Instruct under the
-Apache 2.0 licence. Training data is assembled from tldr-pages (CC-BY 4.0),
+Apache 2.0 for this code — free to use, modify and redistribute, provided the
+licence and `NOTICE` are kept and significant changes are stated. The model
+derives from Qwen2.5-Coder-1.5B-Instruct, also under the Apache 2.0 licence.
+Training data is assembled from tldr-pages (CC-BY 4.0),
 NL2Bash (GPLv3), Fig autocomplete specs (MIT), Warp workflows (Apache 2.0) and
 the NL2SH-ALFA published training split (MIT), deduplicated and audited for
 contamination against the benchmark test set.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,24 @@ and run in CI on Python 3.9 through 3.12.
 Apache 2.0 for this code — free to use, modify and redistribute, provided the
 licence and `NOTICE` are kept and significant changes are stated. The model
 derives from Qwen2.5-Coder-1.5B-Instruct, also under the Apache 2.0 licence.
-Training data is assembled from tldr-pages (CC-BY 4.0),
-NL2Bash (GPLv3), Fig autocomplete specs (MIT), Warp workflows (Apache 2.0) and
-the NL2SH-ALFA published training split (MIT), deduplicated and audited for
-contamination against the benchmark test set.
+
+Training data, by measured row share of the 125,770-row pool:
+
+| source | share | licence |
+|---|---|---|
+| Fig autocomplete specs | 32.8% | MIT |
+| tldr-pages | 23.1% | CC-BY-4.0 |
+| NL2SH-ALFA training split | 18.0% | MIT |
+| cli-commands-explained | 11.8% | CC0-1.0 *(declared, unverified)* |
+| command-generation | 7.3% | Apache-2.0 *(declared, unverified)* |
+| git-instruction | 7.1% | MIT *(declared, unverified)* |
+
+5.67% is verbatim NL2Bash arriving via the ALFA split — its `data/bash` is MIT,
+not GPL. Warp workflows are not used. The three *declared* sources have licences
+we could not independently confirm. Deduplicated, and 0 exact/fuzzy matches
+against the benchmark test set.
+
+**Attribution:** includes content from
+[tldr-pages](https://github.com/tldr-pages/tldr) under
+[CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) (page content is
+CC-BY-4.0; only `scripts/` is MIT).

--- a/nl2sh_pkg/LICENSE
+++ b/nl2sh_pkg/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Mukesh Poudel
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/nl2sh_pkg/NOTICE
+++ b/nl2sh_pkg/NOTICE
@@ -1,0 +1,21 @@
+nl2sh
+Copyright 2026 Mukesh Poudel
+
+This product includes software developed by Mukesh Poudel
+(https://github.com/ThorOdinson246/nl2sh).
+
+Licensed under the Apache License, Version 2.0. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0
+
+---
+
+The accompanying model weights (nl2sh-1.5b-Q4_K_M) are a LoRA fine-tune of
+Qwen2.5-Coder-1.5B-Instruct, Copyright Alibaba Cloud, used under the Apache
+License, Version 2.0.
+
+Training data is assembled from:
+  - tldr-pages                      CC-BY 4.0
+  - NL2Bash                         GPLv3
+  - Fig autocomplete specs          MIT
+  - Warp workflows                  Apache-2.0
+  - NL2SH-ALFA training split       MIT

--- a/nl2sh_pkg/NOTICE
+++ b/nl2sh_pkg/NOTICE
@@ -13,9 +13,19 @@ The accompanying model weights (nl2sh-1.5b-Q4_K_M) are a LoRA fine-tune of
 Qwen2.5-Coder-1.5B-Instruct, Copyright Alibaba Cloud, used under the Apache
 License, Version 2.0.
 
-Training data is assembled from:
-  - tldr-pages                      CC-BY 4.0
-  - NL2Bash                         GPLv3
-  - Fig autocomplete specs          MIT
-  - Warp workflows                  Apache-2.0
-  - NL2SH-ALFA training split       MIT
+Training data, by measured share of the 125,770-row pool:
+
+  32.8%  Fig autocomplete specs      MIT
+  23.1%  tldr-pages                  CC-BY-4.0
+  18.0%  NL2SH-ALFA training split   MIT
+  11.8%  cli-commands-explained      CC0-1.0    (declared, unverified)
+   7.3%  command-generation          Apache-2.0 (declared, unverified)
+   7.1%  git-instruction             MIT        (declared, unverified)
+
+5.67% is verbatim NL2Bash via the ALFA split; its data/bash is MIT, not GPL.
+Warp workflows are not used.
+
+Attribution, required by CC-BY-4.0: this work includes content from tldr-pages
+(https://github.com/tldr-pages/tldr) under CC-BY-4.0
+(https://creativecommons.org/licenses/by/4.0/). Page content is CC-BY-4.0;
+only scripts/ is MIT.

--- a/nl2sh_pkg/pyproject.toml
+++ b/nl2sh_pkg/pyproject.toml
@@ -9,7 +9,7 @@ description = "Natural language to shell command, fully local and fast. No API k
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "Apache-2.0" }
-authors = [{ name = "ThorOdinson246" }]
+authors = [{ name = "Mukesh Poudel" }]
 keywords = ["shell", "cli", "llm", "local", "bash"]
 classifiers = [
   "Environment :: Console",
@@ -27,6 +27,11 @@ dev = ["pytest>=7", "pytest-cov>=4", "ruff>=0.5", "build>=1"]
 
 [project.scripts]
 nl2sh = "nl2sh.cli:main"
+
+[tool.setuptools]
+# Apache-2.0 requires the NOTICE to travel with every redistribution, so it is
+# declared alongside the licence rather than left to setuptools' defaults.
+license-files = ["LICENSE", "NOTICE"]
 
 [tool.setuptools.packages.find]
 include = ["nl2sh*"]


### PR DESCRIPTION
The training-data section was inaccurate in three ways. Corrected against a measured per-row audit of the 125,770-row pool.

| claim before | reality |
|---|---|
| NL2Bash listed as GPLv3 | Present by content (5.67%, via the ALFA split), and its `data/bash` is **MIT**, not GPL — no copyleft exposure |
| Warp workflows listed as a source | **0 rows.** Vendored but never read by any assembly script |
| tldr-pages listed as CC-BY 4.0 | Correct, but the **required attribution was missing** — now added to README and NOTICE |

Also adds measured per-source shares (previously the section listed sources with no proportions), and marks three sources as *declared, unverified*: `cli-commands-explained` declares CC0-1.0 while its own card describes content scraped from CC-BY sources, and `command-generation` / `git-instruction` publish no author or derivation.

The CC-BY-4.0 attribution is the part that matters — it is a licence obligation, not a nicety.

Verified the updated NOTICE still ships inside the wheel (`dist-info/licenses/NOTICE`).