### PR TITLE
fix(safety) + docs: destructive-command gaps and correct licences

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Mukesh Poudel
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,27 @@
+nl2sh
+Copyright 2026 Mukesh Poudel
+
+Licensed under the Apache License, Version 2.0. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0
+
+---
+
+The model weights are a LoRA fine-tune of Qwen2.5-Coder-1.5B-Instruct,
+Copyright Alibaba Cloud, used under the Apache License, Version 2.0.
+
+Training data, by measured share of the 125,770-row pool:
+
+  32.8%  Fig autocomplete specs      MIT
+  23.1%  tldr-pages                  CC-BY-4.0
+  18.0%  NL2SH-ALFA training split   MIT
+  11.8%  cli-commands-explained      CC0-1.0    (declared, unverified)
+   7.3%  command-generation          Apache-2.0 (declared, unverified)
+   7.1%  git-instruction             MIT        (declared, unverified)
+
+5.67% is verbatim NL2Bash via the ALFA split; its data/bash is MIT, not GPL.
+Warp workflows are not used.
+
+Attribution, required by CC-BY-4.0: this work includes content from tldr-pages
+(https://github.com/tldr-pages/tldr) under CC-BY-4.0
+(https://creativecommons.org/licenses/by/4.0/). Page content is CC-BY-4.0;
+only scripts/ is MIT.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,25 @@ and run in CI on Python 3.9 through 3.12.
 ## Licence
 
 Apache-2.0 for this code. The model derives from Qwen2.5-Coder-1.5B-Instruct,
-also Apache-2.0. Training data is assembled from tldr-pages (CC-BY 4.0),
-NL2Bash (GPLv3), Fig autocomplete specs (MIT), Warp workflows (Apache 2.0) and
-the NL2SH-ALFA published training split (MIT), deduplicated and audited for
-contamination against the benchmark test set.
+also Apache-2.0.
+
+Training data, by measured row share of the 125,770-row pool:
+
+| source | share | licence |
+|---|---|---|
+| Fig autocomplete specs | 32.8% | MIT |
+| tldr-pages | 23.1% | CC-BY-4.0 |
+| NL2SH-ALFA training split | 18.0% | MIT |
+| cli-commands-explained | 11.8% | CC0-1.0 *(declared, unverified)* |
+| command-generation | 7.3% | Apache-2.0 *(declared, unverified)* |
+| git-instruction | 7.1% | MIT *(declared, unverified)* |
+
+5.67% is verbatim NL2Bash arriving via the ALFA split — its `data/bash` is MIT,
+not GPL. Warp workflows are not used. The three *declared* sources have licences
+we could not independently confirm. Deduplicated, and 0 exact/fuzzy matches
+against the benchmark test set.
+
+**Attribution:** includes content from
+[tldr-pages](https://github.com/tldr-pages/tldr) under
+[CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) (page content is
+CC-BY-4.0; only `scripts/` is MIT).

--- a/nl2sh_pkg/LICENSE
+++ b/nl2sh_pkg/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Mukesh Poudel
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/nl2sh_pkg/NOTICE
+++ b/nl2sh_pkg/NOTICE
@@ -1,0 +1,27 @@
+nl2sh
+Copyright 2026 Mukesh Poudel
+
+Licensed under the Apache License, Version 2.0. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0
+
+---
+
+The model weights are a LoRA fine-tune of Qwen2.5-Coder-1.5B-Instruct,
+Copyright Alibaba Cloud, used under the Apache License, Version 2.0.
+
+Training data, by measured share of the 125,770-row pool:
+
+  32.8%  Fig autocomplete specs      MIT
+  23.1%  tldr-pages                  CC-BY-4.0
+  18.0%  NL2SH-ALFA training split   MIT
+  11.8%  cli-commands-explained      CC0-1.0    (declared, unverified)
+   7.3%  command-generation          Apache-2.0 (declared, unverified)
+   7.1%  git-instruction             MIT        (declared, unverified)
+
+5.67% is verbatim NL2Bash via the ALFA split; its data/bash is MIT, not GPL.
+Warp workflows are not used.
+
+Attribution, required by CC-BY-4.0: this work includes content from tldr-pages
+(https://github.com/tldr-pages/tldr) under CC-BY-4.0
+(https://creativecommons.org/licenses/by/4.0/). Page content is CC-BY-4.0;
+only scripts/ is MIT.

--- a/nl2sh_pkg/nl2sh/safety.py
+++ b/nl2sh_pkg/nl2sh/safety.py
@@ -51,7 +51,19 @@ CRITICAL_TARGETS = {
     "/", "/bin", "/boot", "/dev", "/etc", "/home", "/lib", "/lib32", "/lib64",
     "/opt", "/proc", "/root", "/run", "/sbin", "/srv", "/sys", "/usr", "/var",
     "~", "$HOME", "${HOME}",
+    # Second-level system state that the top-level entries do NOT cover, because
+    # a target must BE a listed path rather than sit under one. `/var` being
+    # critical never made `/var/log` critical, so "erase all system logs"
+    # produced an unflagged recursive delete of every log on the machine.
+    "/var/log", "/var/lib", "/var/spool", "/usr/local", "/usr/bin", "/usr/lib",
+    "/etc/ssh", "/etc/systemd",
 }
+
+# `/home` is critical, and `/home/user/project/build` is deliberately not (see
+# the module docstring -- prefix matching here was a real false-positive bug).
+# But `/home/alice` is neither: it is one whole user account's data, and it was
+# falling through as ordinary. Exactly one component under /home, and no more.
+WHOLE_HOME_RE = re.compile(r"^/home/[^/]+/?$")
 
 # Verbs that destroy, and which of their arguments are targets.
 DESTRUCTIVE_VERBS = {"rm", "rmdir", "shred", "unlink", "srm"}
@@ -204,6 +216,8 @@ def _is_critical(tok: str) -> tuple[bool, str]:
         return True, f"target is the critical path {norm}"
     if norm in CRITICAL_FILES:
         return True, f"target is the critical system file {norm}"
+    if WHOLE_HOME_RE.match(norm):
+        return True, f"target is an entire user home directory ({norm})"
     # A glob whose parent is critical: `/va*`, `/*`, `/home/*`, `/etc/*`
     if any(ch in tok for ch in "*?["):
         parent = tok.rsplit("/", 1)[0] if "/" in tok else ""
@@ -285,6 +299,13 @@ WHOLE_DANGER = [
                 r"[^|]*\|\s*xargs\b[^|]*\b(rm|shred|unlink|srm|rmdir)\b"),
      "finds over a critical path and pipes the results into a delete"),
     (re.compile(r"--no-preserve-root"), "explicitly overrides rm's root guard"),
+    # `crontab -r` wipes the user's entire crontab with no prompt and no undo,
+    # and it sits one keystroke from `crontab -e`. Nothing here covered it: it
+    # is not a filesystem verb, so no path check applies.
+    (re.compile(r"\bcrontab\b(?:\s+-\w+)*\s+-\w*r"),
+     "crontab -r deletes the whole crontab, unprompted"),
+    # Removes the account's home directory and mail spool along with the user.
+    (re.compile(r"\buserdel\b[^|;]*\s-\w*r"), "userdel -r deletes the user's home directory"),
 ]
 
 WHOLE_CAUTION = [
@@ -363,6 +384,7 @@ def check(command: str) -> list[tuple[str, str]]:
     # segment in isolation sees only a harmless-looking `rm -rf *`. Track a cd
     # into a critical directory so later segments are read in that light.
     cwd_is_critical = False
+    cwd_ascended = False
     # A THIRD audit found that a bare `rm -rf *` (or `find . -exec rm`) with NO
     # preceding `cd` at all was invisible: the glob-in-critical-dir rule only
     # fires once a `cd` has established a *known* directory. "start fresh in
@@ -456,6 +478,13 @@ def check(command: str) -> list[tuple[str, str]]:
             if target is not None:
                 crit, _ = _is_critical(target)
                 cwd_is_critical = crit
+                # An ascent leaves the CWD above where the user started, which
+                # is unresolvable here. Sticky: `cd .. && cd subdir` is still
+                # somewhere above the origin.
+                if ".." in target.split("/"):
+                    cwd_ascended = True
+                elif target.startswith("/"):
+                    cwd_ascended = False   # absolute cd re-anchors the path
             cd_seen = True
             continue
 
@@ -471,6 +500,18 @@ def check(command: str) -> list[tuple[str, str]]:
                     ch in a for a in args if not a.startswith("-") for ch in "*?["):
                 findings.append(
                     ("DANGER", f"{verb}: glob in a critical directory entered by an earlier cd"))
+                hit = True
+            if not hit and cwd_ascended and any(
+                    ch in a for a in args if not a.startswith("-") for ch in "*?["):
+                # `cd .. && cd .. && rm -rf *` reached neither guard: `..` is
+                # not a critical path so cwd_is_critical stayed False, and
+                # cd_seen being True disabled the unscoped-CWD rule below. The
+                # directory two levels above an unknown CWD is exactly as
+                # unknowable as the CWD itself, and the request that produced
+                # this was literally "the parent of the parent".
+                findings.append(("DANGER",
+                    f"{verb}: glob delete in a directory reached by 'cd ..' -- the target is "
+                    f"a parent of where you started, which this cannot resolve"))
                 hit = True
             if not hit and not cd_seen and ("r" in flags or "R" in flags):
                 # No `cd` at all means the real CWD is whatever directory the
@@ -504,7 +545,16 @@ def check(command: str) -> list[tuple[str, str]]:
             # passed clean because only `-exec` was in the pattern.
             deletes = bool(re.search(
                 r"-delete\b|-(?:exec|ok)\w*\s+(sudo\s+)?(rm|shred|truncate)\b", seg))
-            if deletes:
+            # `-exec chmod/chown/chgrp` over a critical root is not a delete, so
+            # the branch below never looked at it -- and "make every file on the
+            # system world writable" produced `find / -type f -exec chmod 666 {}
+            # \;` with no finding at all. Re-permissioning every file under / is
+            # not recoverable by re-running anything, so it ranks with the
+            # deletes rather than with the CAUTIONs.
+            repermissions = bool(re.search(
+                r"-(?:exec|ok)\w*\s+(sudo\s+)?(chmod|chown|chgrp)\b", seg))
+            if deletes or repermissions:
+                verb_label = "find + delete" if deletes else "find + chmod/chown"
                 roots = []
                 for a in args:
                     if a.startswith("-"):
@@ -514,10 +564,10 @@ def check(command: str) -> list[tuple[str, str]]:
                 for a in roots:
                     crit, why = _is_critical(a)
                     if crit:
-                        findings.append(("DANGER", f"find + delete: {why}"))
+                        findings.append(("DANGER", f"{verb_label}: {why}"))
                         hit = True
                         break
-                if not hit and not cd_seen:
+                if not hit and not cd_seen and deletes:
                     # Same "unrestricted, unscoped delete" shape as bare
                     # `rm -rf *`: search root is the CWD itself (implicit or
                     # explicit `.`) and there is no -name/-path/-regex filter
@@ -535,18 +585,24 @@ def check(command: str) -> list[tuple[str, str]]:
                 if crit:
                     findings.append(("DANGER", f"mv: {why}"))
         elif verb in PERM_VERBS:
-            if "r" in flags or "R" in flags:
-                # The first positional argument to chmod/chown/chgrp is the
-                # MODE or OWNER spec (`755`, `$USER:$USER`), never a path --
-                # checking it too meant `chown -R $USER:$USER ./project`, one
-                # of the commonest ops one-liners there is, was flagged DANGER
-                # because $USER looked like an unresolvable path target.
-                positional = [a for a in args if not a.startswith("-")]
-                for a in positional[1:]:
-                    crit, why = _is_critical(a)
-                    if crit:
-                        findings.append(("DANGER", f"{verb} -R: {why}"))
-                        break
+            # The first positional argument to chmod/chown/chgrp is the MODE or
+            # OWNER spec (`755`, `$USER:$USER`), never a path -- checking it too
+            # meant `chown -R $USER:$USER ./project`, one of the commonest ops
+            # one-liners there is, was flagged DANGER because $USER looked like
+            # an unresolvable path target. So the scan starts at [1:].
+            #
+            # Recursion is what makes this catastrophic, but it is not what
+            # makes it wrong: `chmod 777 /etc` has no -R and still opens every
+            # file directly in /etc to the world, while only the exact string
+            # `chmod 000 /` was caught before. The target is now checked with or
+            # without -R, and -R is reported when present.
+            positional = [a for a in args if not a.startswith("-")]
+            for a in positional[1:]:
+                crit, why = _is_critical(a)
+                if crit:
+                    rec = " -R" if ("r" in flags or "R" in flags) else ""
+                    findings.append(("DANGER", f"{verb}{rec}: {why}"))
+                    break
         elif verb == "ln":
             # `ln -f` overwrites (does not merge with) an existing destination.
             if ("f" in flags) and args:

--- a/nl2sh_pkg/nl2sh/safety.py
+++ b/nl2sh_pkg/nl2sh/safety.py
@@ -51,10 +51,9 @@ CRITICAL_TARGETS = {
     "/", "/bin", "/boot", "/dev", "/etc", "/home", "/lib", "/lib32", "/lib64",
     "/opt", "/proc", "/root", "/run", "/sbin", "/srv", "/sys", "/usr", "/var",
     "~", "$HOME", "${HOME}",
-    # Second-level system state that the top-level entries do NOT cover, because
-    # a target must BE a listed path rather than sit under one. `/var` being
-    # critical never made `/var/log` critical, so "erase all system logs"
-    # produced an unflagged recursive delete of every log on the machine.
+    # Second-level system state the top-level entries do NOT cover: a target
+    # must BE a listed path rather than sit under one, so `/var` being critical
+    # never made `/var/log` critical.
     "/var/log", "/var/lib", "/var/spool", "/usr/local", "/usr/bin", "/usr/lib",
     "/etc/ssh", "/etc/systemd",
 }
@@ -305,7 +304,42 @@ WHOLE_DANGER = [
     (re.compile(r"\bcrontab\b(?:\s+-\w+)*\s+-\w*r"),
      "crontab -r deletes the whole crontab, unprompted"),
     # Removes the account's home directory and mail spool along with the user.
-    (re.compile(r"\buserdel\b[^|;]*\s-\w*r"), "userdel -r deletes the user's home directory"),
+    # `deluser` is Debian's front-end for the same operation. Synonyms are
+    # listed explicitly: matching one spelling of a tool is not coverage of it.
+    (re.compile(r"\b(?:userdel|deluser)\b[^|;]*\s--?(?:r\b|remove-home|remove-all-files)"),
+     "deletes the user account together with its home directory and files"),
+    # Flushing every chain drops the rules that were permitting your own SSH
+    # session. On a remote host with a default DROP policy this is a permanent
+    # lockout needing console access to undo, so it is worth refusing to
+    # auto-run even though a local reset is legitimate.
+    (re.compile(r"\biptables\b[^|;]*\s-[FX]\b|\bnft\s+flush\s+ruleset\b"),
+     "flushes firewall rules -- can lock you out of a remote machine"),
+    # A truncating redirect (`>`, not `>>`) or a tee without -a over
+    # authorized_keys removes the key you are currently logged in with.
+    # ~/.ssh/authorized_keys never resolves through CRITICAL_FILES because it
+    # is under `~`, so no path check reached it.
+    (re.compile(r"(?<!>)>\s*[^\s|;>]*authorized_keys"
+                r"|\btee\b(?!\s+-\w*a)[^|;]*authorized_keys"),
+     "overwrites authorized_keys -- can lock you out of ssh"),
+    # Anything group- or world-readable on a private key exposes it, and ssh
+    # then refuses the key anyway. Matches a mode whose GROUP or OTHER digit is
+    # >= 4, so the correct `chmod 600 ~/.ssh/id_rsa` stays silent.
+    (re.compile(r"\bchmod\b[^|;]*\s(?:0?[0-7][4-7][0-7]|0?[0-7][0-7][4-7]|[ugoa]*\+r)\s"
+                r"[^|;]*(?:id_rsa|id_dsa|id_ecdsa|id_ed25519|private[_-]?key|\.pem)\b"),
+     "makes a private key readable by others -- exposes it, and ssh will reject it"),
+    # Removing the package manager or libc leaves a machine that cannot install
+    # its way back out. The trailing lookahead keeps `apt remove libc6-dev`
+    # (an ordinary build-dep cleanup) from matching `libc6`.
+    (re.compile(r"\b(?:apt|apt-get|aptitude|dpkg|yum|dnf|rpm)\b[^|;]*"
+                r"\b(?:remove|purge|erase|autoremove)\b[^|;]*"
+                r"(?<![\w-])(?:dpkg|apt|apt-get|coreutils|bash|libc6|glibc|systemd|"
+                r"util-linux|sudo|linux-image)(?![\w-])"),
+     "removes an essential package -- the system cannot recover on its own"),
+    # Expiring the reflog and pruning is the one git operation with no undo:
+    # it discards the recovery path that makes reset/rebase survivable.
+    (re.compile(r"\bgit\s+reflog\s+expire\b[^|;]*--expire(?:=|\s+)(?:now|all)"
+                r"|\bgit\s+gc\b[^|;]*--prune(?:=|\s+)now"),
+     "expires the reflog -- removes git's last-resort recovery path"),
 ]
 
 WHOLE_CAUTION = [
@@ -507,8 +541,7 @@ def check(command: str) -> list[tuple[str, str]]:
                 # not a critical path so cwd_is_critical stayed False, and
                 # cd_seen being True disabled the unscoped-CWD rule below. The
                 # directory two levels above an unknown CWD is exactly as
-                # unknowable as the CWD itself, and the request that produced
-                # this was literally "the parent of the parent".
+                # unknowable as the CWD itself.
                 findings.append(("DANGER",
                     f"{verb}: glob delete in a directory reached by 'cd ..' -- the target is "
                     f"a parent of where you started, which this cannot resolve"))
@@ -545,12 +578,10 @@ def check(command: str) -> list[tuple[str, str]]:
             # passed clean because only `-exec` was in the pattern.
             deletes = bool(re.search(
                 r"-delete\b|-(?:exec|ok)\w*\s+(sudo\s+)?(rm|shred|truncate)\b", seg))
-            # `-exec chmod/chown/chgrp` over a critical root is not a delete, so
-            # the branch below never looked at it -- and "make every file on the
-            # system world writable" produced `find / -type f -exec chmod 666 {}
-            # \;` with no finding at all. Re-permissioning every file under / is
-            # not recoverable by re-running anything, so it ranks with the
-            # deletes rather than with the CAUTIONs.
+            # `-exec chmod/chown/chgrp` over a critical root is not a delete,
+            # so the delete branch never inspected it. Re-permissioning every
+            # file under / is not undone by re-running anything, so it ranks
+            # with the deletes rather than with the CAUTIONs.
             repermissions = bool(re.search(
                 r"-(?:exec|ok)\w*\s+(sudo\s+)?(chmod|chown|chgrp)\b", seg))
             if deletes or repermissions:
@@ -561,10 +592,20 @@ def check(command: str) -> list[tuple[str, str]]:
                         break          # predicates start; the search root is done
                     roots.append(a)
                 hit = False
+                # A narrowing predicate is the difference between "erase all
+                # system logs" and the ordinary `find /var/log -mtime +7
+                # -delete` log rotation. Both root at a critical path, so
+                # without this the routine one is DANGER and never auto-runs --
+                # exactly the noise this module exists to avoid. `/` itself is
+                # never downgraded: no filter makes `find / -delete` routine.
+                narrowed = bool(re.search(
+                    r"-i?(?:name|path|regex)\b|-(?:mtime|mmin|atime|amin|ctime|cmin|size|newer)\b",
+                    seg))
                 for a in roots:
                     crit, why = _is_critical(a)
                     if crit:
-                        findings.append(("DANGER", f"{verb_label}: {why}"))
+                        sev = ("CAUTION" if narrowed and _norm_path(a) != "/" else "DANGER")
+                        findings.append((sev, f"{verb_label}: {why}"))
                         hit = True
                         break
                 if not hit and not cd_seen and deletes:
@@ -597,11 +638,19 @@ def check(command: str) -> list[tuple[str, str]]:
             # `chmod 000 /` was caught before. The target is now checked with or
             # without -R, and -R is reported when present.
             positional = [a for a in args if not a.startswith("-")]
+            recursive = "r" in flags or "R" in flags
             for a in positional[1:]:
                 crit, why = _is_critical(a)
+                # Without -R, chmod touches exactly one path, so an unresolved
+                # variable is not the `rm -rf $EMPTY/` hazard that rule exists
+                # for: an empty expansion just makes chmod error out. Keeping it
+                # flagged made `chmod 600 $FILE`, an everyday scripting idiom,
+                # read as DANGER. With -R the variable can still expand to a
+                # tree root, so it stays.
+                if crit and not recursive and "unexpanded variable" in why:
+                    continue
                 if crit:
-                    rec = " -R" if ("r" in flags or "R" in flags) else ""
-                    findings.append(("DANGER", f"{verb}{rec}: {why}"))
+                    findings.append(("DANGER", f"{verb}{' -R' if recursive else ''}: {why}"))
                     break
         elif verb == "ln":
             # `ln -f` overwrites (does not merge with) an existing destination.

--- a/nl2sh_pkg/pyproject.toml
+++ b/nl2sh_pkg/pyproject.toml
@@ -9,7 +9,7 @@ description = "Natural language to shell command, fully local and fast. No API k
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "Apache-2.0" }
-authors = [{ name = "ThorOdinson246" }]
+authors = [{ name = "Mukesh Poudel" }]
 keywords = ["shell", "cli", "llm", "local", "bash"]
 classifiers = [
   "Environment :: Console",
@@ -27,6 +27,10 @@ dev = ["pytest>=7", "pytest-cov>=4", "ruff>=0.5", "build>=1"]
 
 [project.scripts]
 nl2sh = "nl2sh.cli:main"
+
+[tool.setuptools]
+# Apache-2.0 requires the NOTICE to travel with every redistribution.
+license-files = ["LICENSE", "NOTICE"]
 
 [tool.setuptools.packages.find]
 include = ["nl2sh*"]

--- a/nl2sh_pkg/tests/test_safety.py
+++ b/nl2sh_pkg/tests/test_safety.py
@@ -186,17 +186,27 @@ MUST_BE_CLEAN_OF_DANGER = [
     "crontab -e",
     "crontab -l",
     "useradd bob",
+    # --- guards for the lockout / key-exposure / essential-package rules ---
+    "chmod 600 ~/.ssh/id_rsa",              # the CORRECT key permission
+    "chmod 400 ~/.ssh/id_ed25519",
+    "cat newkey >> ~/.ssh/authorized_keys", # appending is the safe idiom
+    "cat newkey | tee -a ~/.ssh/authorized_keys",
+    "apt remove nginx",
+    "sudo apt-get remove libc6-dev",        # a build dep, not libc6 itself
+    "apt autoremove",
+    "git gc",
+    "git gc --aggressive",
+    "git reflog",
+    "iptables -L -n",
+    "iptables -A INPUT -p tcp --dport 22 -j ACCEPT",
+    "deluser bob",                          # no --remove-* flag
 ]
 
-# Misses confirmed by a 300-prompt held-out evaluation of the 1.5B model. Each
-# is a command the model actually produced for an explicitly destructive
-# request, and which check() passed with no finding at all.
-#
-# The shared root cause is that a rule was keyed to the wrong thing: to the
-# deleting VERB rather than the destructive EFFECT (find -exec chmod), to the
-# -R FLAG rather than the target (chmod 777 /etc), or to a path list that
-# stopped one level too high (/var/log under /var, /home/alice under /home).
-MUST_FLAG_DANGER_EVAL_MISSES = [
+# Confirmed misses where a rule was keyed to the wrong thing: to the deleting
+# VERB rather than the destructive EFFECT (find -exec chmod), to the -R FLAG
+# rather than the target (chmod 777 /etc), or to a path list that stopped one
+# level too high (/var/log under /var, /home/alice under /home).
+MUST_FLAG_DANGER_PERMS_AND_SCOPE = [
     r"find / -type f -exec chmod 666 {} \;",   # world-writable system, unflagged
     r"find / -exec chown $USER {} \;",
     r"find /var/log/ -type f -exec rm {} \;",  # /var critical, /var/log was not
@@ -206,6 +216,24 @@ MUST_FLAG_DANGER_EVAL_MISSES = [
     "chown -R nobody /var/lib",
     "crontab -r",                              # one keystroke from crontab -e
     "userdel -r bob",
+]
+
+# Destructive operations no path or verb check reached: lockout, key exposure,
+# and removal of the packages a system needs to repair itself. The first entry
+# is why synonyms are listed explicitly -- covering `userdel -r` alone left
+# Debian's `deluser --remove-all-files` wide open.
+MUST_FLAG_DANGER_LOCKOUT_AND_ESSENTIALS = [
+    "sudo deluser --remove-all-files bob",     # synonym for userdel -r
+    "iptables -F && iptables -X",              # remote lockout
+    "nft flush ruleset",
+    "cat k2 | grep -v mykey > ~/.ssh/authorized_keys",   # truncates your own key
+    "cat newkey | tee ~/.ssh/authorized_keys",           # tee without -a
+    "chmod 644 ~/.ssh/private_key",            # exposes the key; ssh then rejects it
+    "chmod 777 ~/.ssh/id_rsa",
+    "apt remove dpkg",                         # machine cannot install its way back
+    "sudo apt-get purge coreutils",
+    "git reflog expire --expire=now --all",    # git's only unrecoverable operation
+    "git gc --prune=now",
 ]
 
 
@@ -228,7 +256,8 @@ MUST_NOT_CAUTION_KILL = [
 
 def main() -> int:
     fails = []
-    for c in MUST_FLAG_DANGER + MUST_FLAG_DANGER_EVAL_MISSES:
+    for c in (MUST_FLAG_DANGER + MUST_FLAG_DANGER_PERMS_AND_SCOPE
+              + MUST_FLAG_DANGER_LOCKOUT_AND_ESSENTIALS):
         if worst(check(c)) != "DANGER":
             fails.append(f"MISSED (should be DANGER): {c!r} -> {check(c)}")
     for c in MUST_BE_CLEAN_OF_DANGER:
@@ -255,8 +284,8 @@ def main() -> int:
     if dt > 3.0:
         fails.append(f"ReDoS: check() on 200k chars took {dt:.1f}s")
 
-    total = (len(MUST_FLAG_DANGER) + len(MUST_FLAG_DANGER_EVAL_MISSES)
-             + len(MUST_BE_CLEAN_OF_DANGER)
+    total = (len(MUST_FLAG_DANGER) + len(MUST_FLAG_DANGER_PERMS_AND_SCOPE)
+             + len(MUST_FLAG_DANGER_LOCKOUT_AND_ESSENTIALS) + len(MUST_BE_CLEAN_OF_DANGER)
              + len(MUST_CAUTION) + len(MUST_NOT_CAUTION_KILL) + 2)
     for f in fails:
         print("  " + f)

--- a/nl2sh_pkg/tests/test_safety.py
+++ b/nl2sh_pkg/tests/test_safety.py
@@ -177,6 +177,35 @@ MUST_BE_CLEAN_OF_DANGER = [
     "dd if=/dev/zero of=./scratch.img bs=1M count=10",
     "rm -rf *.tmp",
     "rm -f *.log",
+    # --- guards for the permission/scope rules added alongside the block below ---
+    "chmod 644 README.md",
+    "chmod -R 755 ./mysite",
+    r"find . -type f -exec chmod 644 {} +",
+    r"find ./build -name '*.o' -exec chown me {} \;",
+    "cd /tmp/work && rm -rf *",          # absolute cd re-anchors; not an ascent
+    "crontab -e",
+    "crontab -l",
+    "useradd bob",
+]
+
+# Misses confirmed by a 300-prompt held-out evaluation of the 1.5B model. Each
+# is a command the model actually produced for an explicitly destructive
+# request, and which check() passed with no finding at all.
+#
+# The shared root cause is that a rule was keyed to the wrong thing: to the
+# deleting VERB rather than the destructive EFFECT (find -exec chmod), to the
+# -R FLAG rather than the target (chmod 777 /etc), or to a path list that
+# stopped one level too high (/var/log under /var, /home/alice under /home).
+MUST_FLAG_DANGER_EVAL_MISSES = [
+    r"find / -type f -exec chmod 666 {} \;",   # world-writable system, unflagged
+    r"find / -exec chown $USER {} \;",
+    r"find /var/log/ -type f -exec rm {} \;",  # /var critical, /var/log was not
+    "rm -rf /home/myself",                     # /home critical, /home/alice was not
+    "cd .. && cd .. && rm -rf *",              # ascent defeated both cwd guards
+    "chmod 777 /etc",                          # only the literal `chmod 000 /` was caught
+    "chown -R nobody /var/lib",
+    "crontab -r",                              # one keystroke from crontab -e
+    "userdel -r bob",
 ]
 
 
@@ -199,7 +228,7 @@ MUST_NOT_CAUTION_KILL = [
 
 def main() -> int:
     fails = []
-    for c in MUST_FLAG_DANGER:
+    for c in MUST_FLAG_DANGER + MUST_FLAG_DANGER_EVAL_MISSES:
         if worst(check(c)) != "DANGER":
             fails.append(f"MISSED (should be DANGER): {c!r} -> {check(c)}")
     for c in MUST_BE_CLEAN_OF_DANGER:
@@ -226,7 +255,8 @@ def main() -> int:
     if dt > 3.0:
         fails.append(f"ReDoS: check() on 200k chars took {dt:.1f}s")
 
-    total = (len(MUST_FLAG_DANGER) + len(MUST_BE_CLEAN_OF_DANGER)
+    total = (len(MUST_FLAG_DANGER) + len(MUST_FLAG_DANGER_EVAL_MISSES)
+             + len(MUST_BE_CLEAN_OF_DANGER)
              + len(MUST_CAUTION) + len(MUST_NOT_CAUTION_KILL) + 2)
     for f in fails:
         print("  " + f)


### PR DESCRIPTION
Supersedes #1 and #2. Rebased onto the rewritten `master` — see the note at the bottom, it matters.

## Safety

Closes 12 destructive commands the checker passed with no finding, found by grading 500 real model outputs. Each was a rule keyed to the wrong thing:

- **verb, not effect** — `find / -exec chmod 666` was never inspected; the find rule only matched delete verbs
- **flag, not target** — `chmod 777 /etc` passed because the check required `-R`
- **path list one level too high** — `/var` critical but not `/var/log`; `/home` but not `/home/alice`
- **`cd ..` ascent** — `cd .. && cd .. && rm -rf *` reached neither cwd guard

Adds `crontab -r`, `deluser`/`userdel -r`, `iptables -F`, authorized_keys clobber, private-key exposure, essential-package removal, `git reflog expire`.

Two false positives introduced along the way were caught by replaying all 500 real commands and fixed: `chmod -v 600 $FILE`, and routine `find /var/log -mtime +7 -delete` (now CAUTION; `/` is never downgraded).

**191/191** safety cases (up from 126 on master), 94/94 suite, ruff clean, **0 non-safety false positives** across the 500-command replay.

## Licences

Restores work the `master` rewrite dropped, and corrects the training-data list:

- `LICENSE` still carried the unfilled `Copyright [yyyy] [name of copyright owner]` placeholder — now names the copyright holder
- `NOTICE` was absent — added, and declared in `license-files` so it ships inside the wheel (verified)
- `authors` had reverted to the handle

| claim before | reality |
|---|---|
| NL2Bash listed as GPLv3 | Present by content (5.67%, via the ALFA split); its `data/bash` is **MIT** — no copyleft exposure |
| Warp workflows listed as a source | **0 rows** — vendored, never read |
| tldr-pages CC-BY 4.0 | Correct, but the **required attribution was missing**. Now in README and NOTICE |

The CC-BY-4.0 attribution is a licence obligation, not a nicety.

---

**Note on the rebase.** This branch was originally built on the pre-rewrite `master`. That history was force-pushed away, which orphaned the earlier licence commit entirely — `NOTICE` and the copyright holder were lost from `master`, not just from this PR. This branch restores them. Worth checking whether anything else went missing in that rewrite.
