### PR TITLE
fix(cli): runtime download size, -- handling, and misplaced flags

### DIFF
--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -165,3 +165,39 @@ class TestBuildParser:
         args = parser.parse_args(["setup", "--model", "/tmp/m.gguf", "--copy"])
         assert args.model == "/tmp/m.gguf"
         assert args.copy is True
+
+
+def test_trailing_flag_is_part_of_the_request_but_is_flagged():
+    """`whatisit list files -e` sends "-e" to the model. That is deliberate
+    (see QueryArgs) but silent, so it must at least be reported."""
+    a = cli.QueryArgs(["list", "files", "-e"])
+    assert a.execute is False
+    assert a.words == ["list", "files", "-e"]
+    assert a.stray_flags == ["-e"]
+
+
+def test_leading_flag_still_acts_as_a_flag():
+    a = cli.QueryArgs(["-e", "list", "files"])
+    assert a.execute is True
+    assert a.words == ["list", "files"]
+    assert a.stray_flags == []
+
+
+def test_double_dash_ends_flags_and_silences_the_note():
+    """`--` means the user meant it literally, so no note."""
+    a = cli.QueryArgs(["list", "files", "--", "-e"])
+    assert a.words == ["list", "files", "-e"]
+    assert a.stray_flags == []
+
+
+def test_flag_shaped_words_that_are_not_our_flags_are_left_alone():
+    """`find files -name test` must not warn: -name is not one of our flags."""
+    a = cli.QueryArgs(["find", "files", "-name", "test"])
+    assert a.words == ["find", "files", "-name", "test"]
+    assert a.stray_flags == []
+
+
+def test_subcommand_word_inside_a_question_stays_a_question():
+    a = cli.QueryArgs(["how", "do", "I", "stop", "a", "stuck", "process"])
+    assert a.words[0] == "how"
+    assert a.stray_flags == []

--- a/whatisit_pkg/tests/test_fetch.py
+++ b/whatisit_pkg/tests/test_fetch.py
@@ -497,3 +497,14 @@ class TestManualPathStillWorks:
         m.write_bytes(b"x")
         monkeypatch.setenv("NL2SH_MODEL", str(m))
         assert cfg_mod.find_model() == m
+
+
+def test_runtime_size_is_the_download_size_not_the_extracted_size():
+    """The prompt offers a size and the progress bar counts one; they must
+    agree. RUNTIME_BYTES is the extracted estimate and is only for the disk
+    check, so it must not leak into the offered figure."""
+    for key in fetch.ASSET_SUFFIX:
+        plan = fetch.runtime_plan(key=key)
+        assert plan["size"] == fetch.ASSET_BYTES[key]
+        assert plan["size"] != fetch.RUNTIME_BYTES
+        assert plan["size"] < fetch.RUNTIME_BYTES

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -80,6 +80,25 @@ def _log_query(prompt: str, cmds: list, elapsed: float, mode: str) -> None:
         pass  # logging must never break the tool
 
 
+def _warn_stray_flags(args) -> None:
+    """Say when a flag ended up inside the request instead of acting as a flag.
+
+    Flags are only read before the request text, for the reasons in QueryArgs.
+    That is the right trade, but it makes `whatisit list files -e` send "-e" to
+    the model, which answers something strange. Silence there is the worst
+    outcome: the user sees a wrong command and no clue why. Goes to stderr, so
+    `$(whatisit -q ...)` stays clean.
+    """
+    stray = getattr(args, "stray_flags", None)
+    if not stray:
+        return
+    first = stray[0]
+    rest = " ".join(w for w in args.words if w not in stray)
+    print(DIM(f"  note: {first} was read as part of your request, not as a flag."),
+          file=sys.stderr)
+    print(DIM(f"        flags go first:  whatisit {first} {rest}"), file=sys.stderr)
+
+
 def cmd_query(args, cfg: dict) -> int:
     prompt = " ".join(args.words).strip()
     if not prompt:
@@ -113,6 +132,7 @@ def cmd_query(args, cfg: dict) -> int:
         print(cmds[0])
         if findings:
             print_findings(findings)
+        _warn_stray_flags(args)
         return 0
 
     for i, c in enumerate(cmds):
@@ -130,6 +150,7 @@ def cmd_query(args, cfg: dict) -> int:
     # Always flush before anything else reaches stderr, so the command is
     # never printed after messages that refer to it.
     sys.stdout.flush()
+    _warn_stray_flags(args)
 
     # Opt-in only (`whatisit config --set log_queries=true`). Shell requests can
     # contain hostnames, paths and credentials, so this is never on by default
@@ -638,6 +659,22 @@ class QueryArgs:
                 break                          # request text starts here
             i += 1
         self.words = argv[i:]
+
+        # A `--` anywhere in the request is an attempt to end the flags, not
+        # part of the question. Drop the first one so `whatisit list files -- -e`
+        # does what it looks like.
+        explicit = "--" in self.words
+        if explicit:
+            cut = self.words.index("--")
+            self.words = self.words[:cut] + self.words[cut + 1:]
+
+        # Flags only count before the request text (see the docstring), so a
+        # trailing `-e` silently becomes part of the question and the model
+        # answers something odd. Record it so the caller can say so rather
+        # than leaving the user to work it out. A `--` means the user already
+        # said they meant it literally, so stay quiet in that case.
+        known = _FLAGS_NOARG | _FLAGS_ARG
+        self.stray_flags = [] if explicit else [w for w in self.words if w in known]
 
 
 def main(argv=None) -> int:

--- a/whatisit_pkg/whatisit/fetch.py
+++ b/whatisit_pkg/whatisit/fetch.py
@@ -55,6 +55,17 @@ MODELS = {
 
 # Rough extracted size of the runtime archive, for the disk-space check.
 RUNTIME_BYTES = 120_000_000
+
+# Download size of each upstream archive, for the "download it?" prompt. These
+# are the compressed tarballs, which is what the progress bar counts, so the
+# figure offered and the figure shown agree. Tied to LLAMA_BUILD: update both
+# together. The compat runtime carries its own size in COMPAT_RUNTIME.
+ASSET_BYTES = {
+    ("Linux", "x86_64"): 16_507_165,
+    ("Linux", "aarch64"): 13_377_770,
+    ("Darwin", "arm64"): 11_015_270,
+    ("Darwin", "x86_64"): 11_290_712,
+}
 USER_AGENT = "whatisit-setup"
 
 # Fallback for Linux boxes below MIN_GLIBC, where the upstream archive downloads
@@ -150,7 +161,11 @@ def runtime_plan(key: tuple | None = None) -> dict:
         return out
 
     def upstream():
-        out.update(kind="upstream", url=asset_url(key=key), size=RUNTIME_BYTES)
+        # size is the DOWNLOAD size, matching what the progress bar counts and
+        # what the compat branch reports. RUNTIME_BYTES is the extracted size
+        # and is used only for the disk-space check.
+        out.update(kind="upstream", url=asset_url(key=key),
+                   size=ASSET_BYTES.get(key, RUNTIME_BYTES))
         return out
 
     if key[0] != "Linux":


### PR DESCRIPTION
Three small things found while running a clean install by hand.

## The size offered did not match the size downloaded

`setup` announced `llama.cpp runtime (120 MB)` and then the bar counted to 17 MB. `plan["size"]` was `RUNTIME_BYTES`, the *extracted* estimate used for the disk-space check, while the compat branch was already reporting its *download* size. So the two runtime paths disagreed with each other.

Adds `ASSET_BYTES` with the real compressed sizes for the pinned `b10333`, tied to `LLAMA_BUILD` with a note to update both together. `RUNTIME_BYTES` stays exactly where it belongs, on the disk check.

| platform | offered now |
|---|---|
| Linux x86_64 | 17 MB |
| Linux aarch64 | 13 MB |
| macOS arm64 / x86_64 | 11 MB |

## A trailing flag silently became part of the request

```
$ whatisit list files changed this week -e
-e
```

Not a parsing bug: `QueryArgs` reads flags only before the request text, and the docstring gives two good reasons (`how do I stop a stuck process` would become the `stop` subcommand, and `find files -name test` would be rejected). That trade is right and this PR does not change it.

But the failure is silent, and the user sees a nonsense command with no clue why. Now it says so:

```
$ whatisit list files changed this week -e
find . -type f -daystart -mtime -7
  note: -e was read as part of your request, not as a flag.
        flags go first:  whatisit -e list files changed this week
```

Only fires when a word exactly matches one of our own flags, so `find files -name test` stays quiet. Goes to stderr, so `$(whatisit -q ...)` is unaffected.

## `--` did nothing

`whatisit list files -- -e` passed `-- -e` through to the model verbatim. The `--` was only honoured while still consuming leading flags, which is the one place nobody needs it. Now it ends the flags anywhere, and its presence suppresses the note above, since the user has already said they meant it literally.

## Tests

Six new cases covering trailing flags, leading flags, `--`, flag-shaped words that are not ours (`-name`), a subcommand word inside a question, and the size invariant. **164 pass**, ruff clean.