### PR TITLE
Fix/os open windows 12

### DIFF
--- a/whatisit_pkg/tests/test_config.py
+++ b/whatisit_pkg/tests/test_config.py
@@ -7,6 +7,7 @@ may read or write the real ~/.config or ~/.local/share.
 import json
 import os
 import stat
+import sys
 
 import pytest
 
@@ -122,6 +123,8 @@ class TestThreadPolicy:
 
 
 class TestSaveConfigPermissions:
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="Unix permission bits are not enforced on Windows")
     def test_config_dir_created_0700(self, monkeypatch, tmp_path):
         _clear_xdg(monkeypatch)
         cdir = tmp_path / "cfgdir"
@@ -130,6 +133,8 @@ class TestSaveConfigPermissions:
         mode = stat.S_IMODE(cdir.stat().st_mode)
         assert mode == 0o700
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="Unix permission bits are not enforced on Windows")
     def test_config_file_created_0600(self, monkeypatch, tmp_path):
         _clear_xdg(monkeypatch)
         cdir = tmp_path / "cfgdir"
@@ -138,6 +143,8 @@ class TestSaveConfigPermissions:
         mode = stat.S_IMODE(p.stat().st_mode)
         assert mode == 0o600
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="Unix permission bits are not enforced on Windows")
     def test_pre_existing_loosely_permissioned_file_gets_fixed(self, monkeypatch, tmp_path):
         # fchmod on the open fd must re-tighten a pre-existing file, not just
         # newly-created ones.

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -7,6 +7,7 @@ to exist.
 """
 import os
 import stat
+import sys
 
 import pytest
 
@@ -82,6 +83,8 @@ class TestStripCliChrome:
 
 # ------------------------------------------------------------- private write
 
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="os.O_NOFOLLOW is not available on Windows")
 class TestWritePrivate:
     def test_creates_file_with_0600(self, tmp_path):
         p = tmp_path / "server.token"

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -83,9 +83,9 @@ class TestStripCliChrome:
 
 # ------------------------------------------------------------- private write
 
-@pytest.mark.skipif(sys.platform == "win32",
-                    reason="os.O_NOFOLLOW is not available on Windows")
 class TestWritePrivate:
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="Unix permission bits are not enforced on Windows")
     def test_creates_file_with_0600(self, tmp_path):
         p = tmp_path / "server.token"
         engine._write_private(p, "supersecret")
@@ -98,6 +98,8 @@ class TestWritePrivate:
         engine._write_private(p, "new")
         assert p.read_text() == "new"
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="Unix permission bits are not enforced on Windows")
     def test_pre_existing_loosely_permissioned_file_is_tightened(self, tmp_path):
         p = tmp_path / "server.token"
         p.write_text("old")
@@ -105,6 +107,8 @@ class TestWritePrivate:
         engine._write_private(p, "new-secret-token")
         assert stat.S_IMODE(p.stat().st_mode) == 0o600
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="os.O_NOFOLLOW is not available on Windows")
     def test_refuses_to_follow_a_symlink(self, tmp_path):
         target = tmp_path / "outside_file.txt"
         target.write_text("do not touch me")

--- a/whatisit_pkg/tests/test_fetch.py
+++ b/whatisit_pkg/tests/test_fetch.py
@@ -255,6 +255,8 @@ class TestExtract:
         with pytest.raises(fetch.FetchError, match="link escapes"):
             fetch.extract_runtime(archive, tmp_path / "dest")
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="absolute symlink error text differs on Windows")
     def test_absolute_symlink_is_rejected(self, tmp_path):
         src = tmp_path / "src" / "llama-b1"
         src.mkdir(parents=True)
@@ -426,6 +428,8 @@ class TestSetupCommand:
         assert cli.cmd_setup(_Args(auto=True, runtime_only=True), cfg) == 0
         assert cfg["force_tcp"] is True
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="asset_url() is None on unsupported Windows host platform")
     def test_upstream_runtime_leaves_the_transport_alone(self, home, monkeypatch, tmp_path):
         monkeypatch.setattr(fetch, "runtime_plan",
                             lambda *a, **k: {"kind": "upstream", "url": "https://x/u.tar.gz",

--- a/whatisit_pkg/tests/test_fetch.py
+++ b/whatisit_pkg/tests/test_fetch.py
@@ -255,8 +255,6 @@ class TestExtract:
         with pytest.raises(fetch.FetchError, match="link escapes"):
             fetch.extract_runtime(archive, tmp_path / "dest")
 
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="absolute symlink error text differs on Windows")
     def test_absolute_symlink_is_rejected(self, tmp_path):
         src = tmp_path / "src" / "llama-b1"
         src.mkdir(parents=True)
@@ -428,16 +426,19 @@ class TestSetupCommand:
         assert cli.cmd_setup(_Args(auto=True, runtime_only=True), cfg) == 0
         assert cfg["force_tcp"] is True
 
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="asset_url() is None on unsupported Windows host platform")
     def test_upstream_runtime_leaves_the_transport_alone(self, home, monkeypatch, tmp_path):
         monkeypatch.setattr(fetch, "runtime_plan",
                             lambda *a, **k: {"kind": "upstream", "url": "https://x/u.tar.gz",
                                              "sha256": None, "size": 10, "reason": "", "warn": ""})
+        # Upstream path calls asset_url/asset_name against the real host
+        # platform; pin them so Windows (and other unsupported hosts) still
+        # exercise the force_tcp omission branch.
+        monkeypatch.setattr(fetch, "asset_url", lambda *a, **k: "https://x/u.tar.gz")
+        monkeypatch.setattr(fetch, "asset_name", lambda *a, **k: "u.tar.gz")
         monkeypatch.setattr(fetch, "existing_llama_server", lambda: None)
         monkeypatch.setattr(fetch, "free_bytes", lambda p: 10 ** 12)
         monkeypatch.setattr(fetch, "release_digests",
-                            lambda b, **k: {fetch.asset_name(b): "abc"})
+                            lambda b, **k: {"u.tar.gz": "abc"})
         monkeypatch.setattr(fetch, "download",
                             lambda url, dest, **k: (dest.parent.mkdir(parents=True, exist_ok=True),
                                                     dest.write_bytes(b"x"), dest)[-1])

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -69,7 +69,11 @@ def _log_query(prompt: str, cmds: list, elapsed: float, mode: str) -> None:
         # chmod leaves the first line -- a real shell request, which can carry
         # hostnames, paths and secrets -- readable at the umask default
         # (group-readable on a shared NFS home) for the width of that window.
-        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW, 0o600)
+        # O_NOFOLLOW is POSIX-only; Windows has no equivalent flag on os.open.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        if os.name != "nt":
+            flags |= os.O_NOFOLLOW
+        fd = os.open(str(path), flags, 0o600)
         try:
             os.fchmod(fd, 0o600)   # also covers a pre-existing, wrongly-permissioned file
         except OSError:
@@ -449,6 +453,8 @@ def _fetch_runtime(args, plan: dict, bin_dir: Path) -> None:
         url = fetch.asset_url(args.llama_version)
     else:
         url = plan["url"]
+    if not url:
+        raise fetch.FetchError("no published runtime for this platform")
 
     print(f"  llama.cpp runtime  ({fetch.fmt_size(plan['size'] or 0)})")
     if not _confirm("download it?", args.auto):

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -116,7 +116,10 @@ def save_config(cfg: dict) -> Path:
     # Create with 0600 from the start rather than write-then-chmod: the latter
     # leaves a window where the file sits at the umask default -- group-readable
     # on the shared-NFS-home clusters this targets -- readable by a co-tenant.
-    fd = os.open(str(p), os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    if os.name == 'nt':
+        fd = os.open(str(p), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    else:
+        fd = os.open(str(p), os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
     # The 0o600 above applies only at CREATION; a pre-existing file keeps
     # whatever mode it had. fchmod on the open fd closes that gap, race-free
     # because it acts on the fd rather than the path.

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -169,7 +169,11 @@ def _write_private(path: Path, text: str) -> None:
     whatever it points to. O_NOFOLLOW turns that into a hard ELOOP failure
     instead of a silent overwrite of an arbitrary file.
     """
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    # O_NOFOLLOW is POSIX-only; Windows has no equivalent flag on os.open.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if os.name != "nt":
+        flags |= os.O_NOFOLLOW
+    fd = os.open(str(path), flags, 0o600)
     try:
         # The 0o600 above applies ONLY when open() creates the file. Without
         # this, a stale group-readable server.token would stay group-readable

--- a/whatisit_pkg/whatisit/fetch.py
+++ b/whatisit_pkg/whatisit/fetch.py
@@ -328,10 +328,13 @@ def _safe_members(tf: tarfile.TarFile, root: Path):
         if not (where + os.sep).startswith(prefix):
             raise FetchError(f"refusing to extract {m.name!r}: escapes the target directory")
         if m.issym() or m.islnk():
-            if os.path.isabs(m.linkname):
+            # POSIX archives use leading '/' for absolute targets; on Windows
+            # os.path.isabs('/etc/shadow') is False, so also catch / and \.
+            ln = m.linkname
+            if os.path.isabs(ln) or ln.startswith(("/", "\\")):
                 raise FetchError(f"refusing to extract {m.name!r}: absolute link target")
             base = os.path.dirname(where) if m.issym() else str(root)
-            dest = os.path.normpath(os.path.join(base, m.linkname))
+            dest = os.path.normpath(os.path.join(base, ln))
             if not (dest + os.sep).startswith(prefix):
                 raise FetchError(f"refusing to extract {m.name!r}: link escapes the target")
         yield m


### PR DESCRIPTION
## What does this change do, and why?

Windows support changes for issue #12 and other stuff found including test suite.

(Got Grok to summarize and then I summarized its summary:)

Production changes

1. O_NOFOLLOW is POSIX-only
   os.open(..., O_NOFOLLOW) raises AttributeError on Windows.
   Fix: omit that flag when os.name == "nt" in:
   • config.save_config
   • engine._write_private
   • CLI query-log append

   Unix still uses O_NOFOLLOW (symlink redirect protection). Windows writes without it (same residual risk as other tools without that flag).

2. Tar absolute-symlink check (fetch)
   On Windows, os.path.isabs("/etc/shadow") is false, so absolute POSIX links were misclassified as “escapes” instead of “absolute”.
   Fix: also treat link targets starting with / or \ as absolute.

3. Setup when there is no runtime URL (cli._fetch_runtime)
   On unsupported hosts (including Windows), asset_url() can be None and then .rsplit crashed.
   Fix: raise a clear FetchError if url is missing.

Tests

• skipif(sys.platform == "win32") for checks that only make sense on Unix:
  • permission modes 0o600 / 0o700 (NTFS doesn’t enforce them like POSIX)
  • O_NOFOLLOW symlink-refusal behaviour
• Un-skipped / fixed where possible:
  • private-file overwrite works after the open-flag fix
  • absolute symlink reject after the fetch fix
  • upstream setup test mocks asset_url / asset_name so it doesn’t depend on host platform

Result on Windows: 158 passed, 6 skipped.

## How was it tested?

- [x] `pytest -q` passes locally (`whatisit_pkg/`)
- [x] `ruff check .` is clean (or new findings are explained below)
- [x] If this touches `safety.py` or `extract.py`: no case was removed or
      weakened in `tests/test_safety.py` / `tests/test_extract.py` -- only
      added to

## Anything reviewers should look at closely?

Not really. Some other features that would be helpful: LMStudio support (less of a pain to install this and your model works fine there), have prompt in windows default to 'powershell' which seems to work for getting powershell commands (not sure how well though):

```
> lms chat --dont-fetch-catalog -s "You are a shell command generator. Output exactly one line: a single bash command that accomplishes the user's request. No prose, no markdown fences, no explanation." -p "list my running processes"
ps -u $USER -o "pid= %p,%c %a" | tail
```