### PR TITLE
Tolerate a missing os.fchmod on Windows

### DIFF
--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -76,7 +76,7 @@ def _log_query(prompt: str, cmds: list, elapsed: float, mode: str) -> None:
         fd = os.open(str(path), flags, 0o600)
         try:
             os.fchmod(fd, 0o600)   # also covers a pre-existing, wrongly-permissioned file
-        except OSError:
+        except (OSError, AttributeError):
             pass
         with os.fdopen(fd, "a", encoding="utf-8") as f:
             f.write(json.dumps(rec, ensure_ascii=False) + "\n")

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -125,7 +125,7 @@ def save_config(cfg: dict) -> Path:
     # because it acts on the fd rather than the path.
     try:
         os.fchmod(fd, 0o600)
-    except OSError:
+    except (OSError, AttributeError):
         pass
     with os.fdopen(fd, "w") as f:
         f.write(json.dumps(cfg, indent=2) + "\n")

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -180,7 +180,7 @@ def _write_private(path: Path, text: str) -> None:
         # across every restart, on exactly the shared-NFS-home clusters this
         # targets.
         os.fchmod(fd, 0o600)
-    except OSError:
+    except (OSError, AttributeError):
         pass
     with os.fdopen(fd, "w") as f:
         f.write(text)


### PR DESCRIPTION
Follow-up to #13. os.fchmod only gained Windows support in 3.13, and pyproject claims 3.9+, so on older Pythons the O_NOFOLLOW fix just moves the crash two lines down. except OSError does not catch an AttributeError.

Verified by removing os.fchmod at runtime: crashes on #13 as merged, succeeds with this. 164 tests still pass on Linux, ruff clean.