### PR TITLE
Recommend pipx for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ cloud API isn't allowed.
 ## Install
 
 ```bash
-pip install whatisit
+pipx install whatisit
 whatisit setup
 ```
+
+`pip install whatisit` works too, inside a virtualenv or on conda.
 
 `setup` works out what your machine needs, tells you the size of each download
 and asks before starting it, then checks the files it fetched. On Linux with a
@@ -42,7 +44,7 @@ Three pieces: the CLI, the model file, and a `llama.cpp` build to run it.
 **1. The CLI.**
 
 ```bash
-pip install whatisit
+pipx install whatisit
 ```
 
 Or from source, if you want to hack on it:

--- a/whatisit_pkg/README.md
+++ b/whatisit_pkg/README.md
@@ -17,9 +17,11 @@ rm -rf /
 ## Install
 
 ```bash
-pip install whatisit
+pipx install whatisit
 whatisit setup
 ```
+
+`pip install whatisit` works too, inside a virtualenv or on conda.
 
 `setup` fetches the model and a `llama.cpp` runtime, asking before each
 download and verifying the checksum afterwards. On Linux with a glibc older


### PR DESCRIPTION
pip install into a system python now fails with externally-managed-environment on Debian, Ubuntu, Fedora and Arch, which is the first command in the README.

Tested pipx install end to end: setup, doctor, a real query and stop all work, since the config and data dirs live outside the venv.

Same change in whatisit_pkg/README.md, which is the PyPI page.