### PR TITLE
chore(packaging): package for nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ runtime/lib/
 runtime/raw.txt
 scratch/
 
+# Nix build symlink.
+/result
+
 # Ollama models, wherever a script materializes them.
 ollama_models/
 *.ollama/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,43 @@ whatisit doctor
 
 Python 3.9+, Linux or macOS. The CLI has no dependencies of its own.
 
+### Nix
+
+Run without installing:
+
+```bash
+nix run github:ThorOdinson246/whatisit-nl2sh -- setup        # fetch the model
+nix run github:ThorOdinson246/whatisit-nl2sh -- list files changed this week
+```
+
+Install on your system:
+
+```bash
+# ad-hoc, as a user
+nix profile install github:ThorOdinson246/whatisit-nl2sh
+
+# or from a local checkout
+nix profile install .#whatisit
+```
+
+On NixOS, add it to your flake inputs and to `environment.systemPackages`:
+
+```nix
+{
+  inputs.whatisit-nl2sh.url = "github:ThorOdinson246/whatisit-nl2sh";
+
+  outputs = { self, nixpkgs, whatisit-nl2sh, ... }: {
+    nixosConfigurations.my_system = nixpkgs.lib.nixosSystem {
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [ whatisit-nl2sh.packages.${pkgs.stdenv.hostPlatform.system}.default ];
+        })
+      ];
+    };
+  };
+}
+```
+
 ## Use
 
 Type the request as plain arguments. No quoting needed:

--- a/README.md
+++ b/README.md
@@ -84,40 +84,13 @@ Python 3.9+, Linux or macOS. The CLI has no dependencies of its own.
 
 ### Nix
 
-Run without installing:
-
 ```bash
-nix run github:ThorOdinson246/whatisit-nl2sh -- setup        # fetch the model
-nix run github:ThorOdinson246/whatisit-nl2sh -- list files changed this week
-```
-
-Install on your system:
-
-```bash
-# ad-hoc, as a user
+nix run github:ThorOdinson246/whatisit-nl2sh -- setup
 nix profile install github:ThorOdinson246/whatisit-nl2sh
-
-# or from a local checkout
-nix profile install .#whatisit
 ```
 
-On NixOS, add it to your flake inputs and to `environment.systemPackages`:
-
-```nix
-{
-  inputs.whatisit-nl2sh.url = "github:ThorOdinson246/whatisit-nl2sh";
-
-  outputs = { self, nixpkgs, whatisit-nl2sh, ... }: {
-    nixosConfigurations.my_system = nixpkgs.lib.nixosSystem {
-      modules = [
-        ({ pkgs, ... }: {
-          environment.systemPackages = [ whatisit-nl2sh.packages.${pkgs.stdenv.hostPlatform.system}.default ];
-        })
-      ];
-    };
-  };
-}
-```
+The flake wires in `llama.cpp` from nixpkgs, so `setup` only fetches the model.
+On NixOS, add the flake to your inputs and pull `packages.<system>.default`.
 
 ## Use
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
 
   outputs = { self, nixpkgs }:
     let
-      # Keep this in sync with whatisit_pkg/pyproject.toml.
-      version = "0.2.1";
+      version = (builtins.fromTOML
+        (builtins.readFile ./whatisit_pkg/pyproject.toml)).project.version;
 
       eachSystem = f: nixpkgs.lib.genAttrs
         [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "whatisit: natural language to shell command, fully local";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      # Keep this in sync with whatisit_pkg/pyproject.toml.
+      version = "0.2.1";
+
+      eachSystem = f: nixpkgs.lib.genAttrs
+        [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]
+        (system: f system (nixpkgs.legacyPackages.${system}));
+    in
+    {
+      packages = eachSystem (system: pkgs: {
+        whatisit = pkgs.python3.pkgs.buildPythonApplication {
+          pname = "whatisit";
+          inherit version;
+          src = ./whatisit_pkg;
+          format = "pyproject";
+
+          nativeBuildInputs = [ pkgs.makeWrapper pkgs.python3.pkgs.setuptools ];
+          nativeCheckInputs = [ pkgs.python3.pkgs.pytestCheckHook ];
+
+          # The model (941 MB) is deliberately NOT bundled: fetch it once with
+          # `whatisit setup --model /path/to/model.gguf`. The runtime comes
+          # from Nix instead of the tool's own downloader.
+          postInstall = ''
+            wrapProgram $out/bin/whatisit \
+              --set WHATISIT_LLAMA_SERVER ${pkgs.llama-cpp}/bin/llama-server \
+              --set WHATISIT_LLAMA_CLI ${pkgs.llama-cpp}/bin/llama-cli
+          '';
+        };
+        default = self.packages.${system}.whatisit;
+      });
+
+      devShells = eachSystem (system: pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            self.packages.${system}.whatisit
+            (pkgs.python3.withPackages (ps: [ ps.pytest ps.pytest-cov ps.ruff ps.build ]))
+            pkgs.llama-cpp
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
## What does this change do, and why?
With this PR `whatisit` can be used or installed with the Nix package manager or on NixOS.

## How was it tested?
Used and installed from my fork.

## Anything reviewers should look at closely?
Heads-up: `flake.nix` needs a version bump on release.