### PR TITLE
Feature: LM Studio Support

### DIFF
--- a/whatisit_pkg/tests/test_fetch.py
+++ b/whatisit_pkg/tests/test_fetch.py
@@ -299,6 +299,8 @@ def home(monkeypatch, tmp_path):
         monkeypatch.delenv(v, raising=False)
     monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
     monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+    # Isolate from a developer machine that has LM Studio on PATH.
+    monkeypatch.setattr(cli.lms_backend, "find_lms", lambda: None)
     return tmp_path
 
 

--- a/whatisit_pkg/tests/test_lms.py
+++ b/whatisit_pkg/tests/test_lms.py
@@ -1,0 +1,235 @@
+"""LM Studio CLI backend: discovery, load/chat, and engine selection."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from whatisit import config as cfg_mod
+from whatisit import engine, lms_backend
+
+
+class TestResolveModelKey:
+    def test_pin_wins(self, tmp_path):
+        cfg = {"lms_path": str(tmp_path / "lms"), "lms_model": "nl2sh-3b"}
+        assert lms_backend.resolve_model_key(cfg) == "nl2sh-3b"
+
+    def test_unique_nl2sh_prefix(self, monkeypatch, tmp_path):
+        lms = tmp_path / "lms.exe"
+        lms.write_text("")
+        cfg = {"lms_path": str(lms)}
+
+        def fake_list(p):
+            return [
+                {"type": "llm", "modelKey": "other-model"},
+                {"type": "llm", "modelKey": "nl2sh-1.5b"},
+            ]
+
+        monkeypatch.setattr(lms_backend, "list_models", fake_list)
+        assert lms_backend.resolve_model_key(cfg, lms) == "nl2sh-1.5b"
+
+    def test_multiple_nl2sh_requires_pin(self, monkeypatch, tmp_path):
+        lms = tmp_path / "lms"
+        lms.write_text("")
+        cfg = {"lms_path": str(lms)}
+        monkeypatch.setattr(
+            lms_backend, "list_models",
+            lambda p: [{"type": "llm", "modelKey": "nl2sh-1.5b"},
+                       {"type": "llm", "modelKey": "nl2sh-3b"}],
+        )
+        with pytest.raises(lms_backend.LmsError, match="multiple nl2sh"):
+            lms_backend.resolve_model_key(cfg, lms)
+
+    def test_none_is_unavailable(self, monkeypatch, tmp_path):
+        lms = tmp_path / "lms"
+        lms.write_text("")
+        cfg = {"lms_path": str(lms)}
+        monkeypatch.setattr(lms_backend, "list_models", lambda p: [])
+        with pytest.raises(lms_backend.LmsUnavailable, match="no nl2sh"):
+            lms_backend.resolve_model_key(cfg, lms)
+
+
+class TestEnsureLoaded:
+    def test_skips_load_when_already_in_ps(self, monkeypatch, tmp_path):
+        lms = tmp_path / "lms"
+        lms.write_text("")
+        cfg = {"lms_path": str(lms), "lms_model": "nl2sh-1.5b"}
+        monkeypatch.setattr(
+            lms_backend, "list_models",
+            lambda p: [{"type": "llm", "modelKey": "nl2sh-1.5b"}],
+        )
+        monkeypatch.setattr(lms_backend, "is_loaded", lambda p, k: True)
+        calls = []
+
+        def boom(*a, **k):
+            calls.append(a)
+            raise AssertionError("load should not run")
+
+        monkeypatch.setattr(lms_backend, "_run", boom)
+        assert lms_backend.ensure_loaded(cfg) == "nl2sh-1.5b"
+        assert calls == []
+
+    def test_load_passes_ttl_when_configured(self, monkeypatch, tmp_path):
+        lms = tmp_path / "lms"
+        lms.write_text("")
+        cfg = {"lms_path": str(lms), "lms_model": "nl2sh-1.5b", "lms_ttl": 600}
+        monkeypatch.setattr(
+            lms_backend, "list_models",
+            lambda p: [{"type": "llm", "modelKey": "nl2sh-1.5b"}],
+        )
+        monkeypatch.setattr(lms_backend, "is_loaded", lambda p, k: False)
+        seen = []
+
+        def fake_run(path, args, timeout=120.0):
+            seen.append(args)
+            class R:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(lms_backend, "_run", fake_run)
+        lms_backend.ensure_loaded(cfg)
+        assert seen == [["load", "nl2sh-1.5b", "-y", "--ttl", "600"]]
+
+    def test_load_omits_ttl_when_unset(self, monkeypatch, tmp_path):
+        lms = tmp_path / "lms"
+        lms.write_text("")
+        cfg = {"lms_path": str(lms), "lms_model": "nl2sh-1.5b"}
+        monkeypatch.setattr(
+            lms_backend, "list_models",
+            lambda p: [{"type": "llm", "modelKey": "nl2sh-1.5b"}],
+        )
+        monkeypatch.setattr(lms_backend, "is_loaded", lambda p, k: False)
+        seen = []
+
+        def fake_run(path, args, timeout=120.0):
+            seen.append(args)
+            class R:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(lms_backend, "_run", fake_run)
+        lms_backend.ensure_loaded(cfg)
+        assert seen == [["load", "nl2sh-1.5b", "-y"]]
+
+
+class TestChat:
+    def test_returns_stdout(self, monkeypatch, tmp_path):
+        lms = tmp_path / "lms"
+        lms.write_text("")
+        cfg = {"lms_path": str(lms), "lms_model": "nl2sh-1.5b"}
+        monkeypatch.setattr(lms_backend, "ensure_loaded", lambda c, key=None: "nl2sh-1.5b")
+
+        def fake_run(path, args, timeout=120.0):
+            assert args[0] == "chat"
+            assert "--dont-fetch-catalog" in args
+            assert "-p" in args
+            class R:
+                returncode = 0
+                stdout = "ps aux\n"
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(lms_backend, "_run", fake_run)
+        assert lms_backend.chat(cfg, "sys", "list processes") == "ps aux"
+
+
+class TestEngineSelection:
+    def _host(self, monkeypatch):
+        class H:
+            @staticmethod
+            def build(prompt, enabled=True, cwd=None):
+                return "SYS", prompt
+        monkeypatch.setattr(engine, "hostctx", H)
+
+    def test_legacy_uses_server_not_lms(self, monkeypatch, tmp_path):
+        self._host(monkeypatch)
+        model = tmp_path / "m.gguf"
+        model.write_bytes(b"x")
+        monkeypatch.setattr(cfg_mod, "find_model", lambda: model)
+        srv = tmp_path / "llama-server"
+        srv.write_bytes(b"x")
+        monkeypatch.setenv("WHATISIT_LLAMA_SERVER", str(srv))
+        monkeypatch.setattr(engine, "start_server", lambda *a, **k: 9)
+        monkeypatch.setattr(
+            engine, "_query_server",
+            lambda *a, **k: [("ls -la", "stop")],
+        )
+        lms_calls = []
+
+        def no_lms(*a, **k):
+            lms_calls.append(1)
+            raise AssertionError("lms must not run in legacy mode")
+
+        monkeypatch.setattr(engine, "_query_lms", no_lms)
+        cmds, _, mode = engine.generate("list files", {})
+        assert cmds == ["ls -la"] and mode == "server" and lms_calls == []
+
+    def test_primary_lms(self, monkeypatch, tmp_path):
+        self._host(monkeypatch)
+        monkeypatch.setattr(
+            engine, "_query_lms",
+            lambda cfg, user, n, system: [("ps aux", "stop")],
+        )
+        # llama missing should not matter when lms is configured
+        monkeypatch.setattr(cfg_mod, "find_model", lambda: None)
+        cfg = {"backend_primary": "lms", "lms_path": str(tmp_path / "lms")}
+        cmds, _, mode = engine.generate("list processes", cfg)
+        assert cmds == ["ps aux"] and mode == "lms"
+
+    def test_lms_unavailable_does_not_silently_use_llama(self, monkeypatch, tmp_path):
+        self._host(monkeypatch)
+        model = tmp_path / "m.gguf"
+        model.write_bytes(b"x")
+        monkeypatch.setattr(cfg_mod, "find_model", lambda: model)
+
+        def fail_lms(cfg, user, n, system):
+            raise lms_backend.LmsUnavailable("no lms")
+
+        monkeypatch.setattr(engine, "_query_lms", fail_lms)
+        cfg = {"backend_primary": "lms", "lms_path": str(tmp_path / "missing")}
+        with pytest.raises(lms_backend.LmsUnavailable, match="no lms"):
+            engine.generate("noop", cfg)
+
+
+class TestJsonHelpers:
+    def test_list_models_parses_array(self, monkeypatch, tmp_path):
+        lms = tmp_path / "lms"
+        lms.write_text("")
+        payload = [{"type": "llm", "modelKey": "nl2sh-1.5b"}]
+
+        def fake_run(path, args, timeout=120.0):
+            class R:
+                returncode = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(lms_backend, "_run", fake_run)
+        assert lms_backend.list_models(lms) == payload
+
+
+class TestSubprocessEncoding:
+    def test_run_forces_utf8_not_locale_codepage(self, monkeypatch, tmp_path):
+        """Windows defaults text=True to cp1252; lms emits UTF-8 spinners/glyphs."""
+        lms = tmp_path / "lms"
+        lms.write_text("")
+        seen = {}
+
+        def fake_run(*a, **kw):
+            seen.update(kw)
+            class R:
+                returncode = 0
+                stdout = "ps aux\n"
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(lms_backend.subprocess, "run", fake_run)
+        r = lms_backend._run(lms, ["chat", "m", "-p", "x"])
+        assert r.stdout == "ps aux\n"
+        assert seen.get("encoding") == "utf-8"
+        assert seen.get("errors") == "replace"
+        assert seen.get("text") is True

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 from . import config as cfg_mod
-from . import engine, fetch
+from . import engine, fetch, lms_backend
 from .safety import check
 
 # Colour only when attached to a terminal, and honour NO_COLOR.
@@ -163,7 +163,12 @@ def cmd_query(args, cfg: dict) -> int:
         _log_query(prompt, cmds, elapsed, mode)
 
     if args.timing:
-        print(DIM(f"  [{elapsed:.2f}s, {mode} mode]"), file=sys.stderr)
+        mode_label = {
+            "server": "llama-server",
+            "oneshot": "llama-cli",
+            "lms": "LM Studio (lms)",
+        }.get(mode, mode)
+        print(DIM(f"  [{elapsed:.2f}s, {mode_label}]"), file=sys.stderr)
 
     if not args.execute:
         return 0
@@ -231,6 +236,125 @@ def _confirm(prompt: str, auto: bool) -> bool:
         return False
 
 
+def _llama_present() -> bool:
+    """True when a llama-server or llama-cli binary is already available."""
+    if cfg_mod.find_llama_cli() is not None:
+        return True
+    sb = cfg_mod.env("LLAMA_SERVER")
+    if sb and Path(sb).exists():
+        return True
+    if (cfg_mod.data_dir() / "bin" / "llama-server").exists():
+        return True
+    if shutil.which("llama-server"):
+        return True
+    return False
+
+
+def _prompt_choice(prompt: str, choices: dict[str, str], default: str) -> str:
+    """Interactive single-letter (or key) choice. choices: key -> label."""
+    keys = list(choices)
+    hint = "/".join(f"{k}={choices[k]}" for k in keys)
+    while True:
+        try:
+            ans = input(f"  {prompt} [{hint}] (default {default}): ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return default
+        if not ans:
+            return default
+        if ans in choices:
+            return ans
+        # also accept unique label prefixes
+        matches = [k for k, lab in choices.items() if lab.startswith(ans) or k == ans]
+        if len(matches) == 1:
+            return matches[0]
+        print(f"  choose one of: {', '.join(keys)}")
+
+
+def _set_backend_llama(cfg: dict) -> None:
+    cfg["backend_primary"] = "llama"
+    cfg.pop("backend_fallback", None)  # legacy key; single backend only
+    cfg.pop("lms_path", None)
+    cfg.pop("lms_model", None)
+
+
+def _set_backend_lms(cfg: dict, lms: Path) -> None:
+    cfg["backend_primary"] = "lms"
+    cfg.pop("backend_fallback", None)  # legacy key; single backend only
+    cfg["lms_path"] = str(lms)
+
+
+def _configure_backends(args, cfg: dict) -> tuple[str | None, bool]:
+    """Pick exactly one backend: llama.cpp or LM Studio (lms).
+
+    Returns (selected_primary, need_llama_assets).
+    need_llama_assets is False when the user chose lms (skip llama download).
+    """
+    has_llama = _llama_present()
+    lms = lms_backend.find_lms()
+    has_lms = lms is not None
+    auto = bool(getattr(args, "auto", False))
+
+    if not has_llama and not has_lms:
+        # Existing install path will fetch llama.cpp.
+        _set_backend_llama(cfg)
+        return "llama", True
+
+    if has_llama and not has_lms:
+        _set_backend_llama(cfg)
+        print(f"  backend: {GREEN('llama')} (llama.cpp; LM Studio CLI not on PATH)")
+        return "llama", True
+
+    if has_lms and not has_llama:
+        _set_backend_lms(cfg, lms)
+        print(f"  backend: {GREEN('lms')} (LM Studio CLI)  {lms}")
+        return "lms", False
+
+    # Both present: one choice only (no dual-backend / fallback).
+    if auto or not sys.stdin.isatty():
+        _set_backend_llama(cfg)
+        why = "--auto" if auto else "no TTY"
+        print(f"  backend: {GREEN('llama')} (llama.cpp; both installed, {why}; "
+              f"re-run setup interactively or "
+              f"`whatisit config --set backend_primary=lms`)")
+        return "llama", True
+
+    print(f"  found llama.cpp runtime and LM Studio CLI ({lms})")
+    which = _prompt_choice(
+        "use which backend? (one only)",
+        {"l": "llama.cpp", "m": "LM-Studio"},
+        "l",
+    )
+    if which == "m":
+        _set_backend_lms(cfg, lms)
+        print(f"  backend: {GREEN('lms')} (LM Studio CLI)  {lms}")
+        return "lms", False
+    _set_backend_llama(cfg)
+    print(f"  backend: {GREEN('llama')} (llama.cpp)")
+    return "llama", True
+
+
+def _setup_lms_model(cfg: dict) -> int:
+    """Ensure an nl2sh model is visible to lms. 0 ok, 1 fail with instructions."""
+    try:
+        lms = lms_backend.lms_path(cfg)
+        keys = lms_backend.nl2sh_keys(lms_backend.list_models(lms))
+    except lms_backend.LmsError as e:
+        print(f"  {RED('lms')}: {e}", file=sys.stderr)
+        return 1
+    if len(keys) == 1:
+        print(f"  lms model: {keys[0]}")
+        return 0
+    if len(keys) > 1:
+        print(f"  {YELLOW('multiple nl2sh models')}: {', '.join(keys)}")
+        print("  pin one:  whatisit config --set lms_model=<key>")
+        # Still usable once pinned; do not fail setup hard if user will pin.
+        return 0
+    print(f"  {RED('no nl2sh model')} in LM Studio")
+    print(f"  {lms_backend.model_get_instructions()}")
+    return 1
+
+
 def _progress(got: int, total: int) -> None:
     if not total:
         return
@@ -283,10 +407,20 @@ def cmd_setup(args, cfg: dict) -> int:
     models_dir = cfg_mod.data_dir() / "models"
     bin_dir = cfg_mod.data_dir() / "bin"
 
+    primary, need_llama = _configure_backends(args, cfg)
+    if primary == "lms":
+        if _setup_lms_model(cfg) != 0:
+            return 1
+
     # An explicit path means the manual path, which is unchanged. Otherwise
     # bare `setup` fetches what is missing.
     if not (args.model or args.bin_dir):
+        if not need_llama and primary == "lms":
+            return _finish_setup(cfg)
         return _setup_auto(args, cfg, models_dir, bin_dir)
+
+    if not need_llama and primary == "lms" and not (args.model or args.bin_dir):
+        return _finish_setup(cfg)
 
     models_dir.mkdir(parents=True, exist_ok=True)
     bin_dir.mkdir(parents=True, exist_ok=True)
@@ -318,7 +452,7 @@ def cmd_setup(args, cfg: dict) -> int:
         else:
             target.symlink_to(src)
             print(f"  linked model: {target} -> {src}")
-    else:
+    elif need_llama:
         print(f"  {YELLOW('no model yet.')} Provide one with:")
         print(f"    whatisit setup --model /path/to/{cfg_mod.MODEL_NAME}")
         print(DIM("  (a released build would download it from the model hub here)"))
@@ -362,7 +496,7 @@ def _setup_auto(args, cfg: dict, models_dir: Path, bin_dir: Path) -> int:
         print(f"  model present: {model_file.name} "
               f"({model_file.stat().st_size / 1e6:.0f} MB)")
     if want_runtime and not need_runtime:
-        print(f"  runtime present: {server}")
+        print(f"  llama.cpp runtime present: {server}")
 
     plan = {"kind": "none", "reason": "", "warn": "", "url": None,
             "sha256": None, "size": 0}
@@ -476,7 +610,7 @@ def _fetch_runtime(args, plan: dict, bin_dir: Path) -> None:
             dest.unlink()
         shutil.move(str(item), str(dest))
     shutil.rmtree(staging / "unpacked", ignore_errors=True)
-    print(f"  runtime installed: {bin_dir}")
+    print(f"  llama.cpp runtime installed: {bin_dir}")
 
 
 def _fetch_model(args, spec: dict, model_file: Path, slot: Path) -> None:
@@ -496,9 +630,40 @@ def _fetch_model(args, spec: dict, model_file: Path, slot: Path) -> None:
         print(f"  registered: {slot.name} -> {model_file.name}")
 
 
+def _doctor_row(kind: str, field: str, detail: str) -> None:
+    """One aligned doctor line: status (4) | field (12) | detail.
+
+    Colour is applied after padding so ANSI codes do not shift columns.
+    """
+    plain = f"{kind:<4}"[:4] if len(kind) >= 4 else f"{kind:<4}"
+    if kind == "ok":
+        status = GREEN(plain)
+    elif kind == "FAIL":
+        status = RED(plain)
+    elif kind == "warn":
+        status = YELLOW(plain)
+    elif kind == "skip":
+        status = DIM(plain)
+    else:
+        status = plain  # info / idle
+    print(f"  {status}  {field:<12}  {detail}")
+
+
 def cmd_doctor(args, cfg: dict) -> int:
     print(BOLD("whatisit doctor"))
     ok = True
+
+    primary = cfg.get("backend_primary")
+    if primary == "llama":
+        _doctor_row("info", "backend", "llama  (llama.cpp)")
+    elif primary == "lms":
+        _doctor_row("info", "backend", "lms  (LM Studio CLI)")
+    else:
+        _doctor_row("info", "backend",
+                    "legacy auto (llama-server/cli; LM Studio not used until setup)")
+
+    uses_llama = (not primary) or primary == "llama"
+    uses_lms = primary == "lms"
 
     model = cfg_mod.find_model()
     if model:
@@ -507,31 +672,93 @@ def cmd_doctor(args, cfg: dict) -> int:
         # otherwise doctor names the wrong model.
         actual = model.resolve().name if model.is_symlink() else model.name
         suffix = f"  [{actual}]" if actual != model.name else ""
-        print(f"  {GREEN('ok')}    model      {model} "
-              f"({model.stat().st_size / 1e6:.0f} MB){suffix}")
-    else:
-        print(f"  {RED('FAIL')}  model      not found -- run `whatisit setup --model ...`")
+        _doctor_row("ok", "llama model",
+                    f"{model} ({model.stat().st_size / 1e6:.0f} MB){suffix}")
+    elif uses_llama:
+        _doctor_row("FAIL", "llama model",
+                    "not found -- run `whatisit setup --model ...`")
         ok = False
+    else:
+        _doctor_row("skip", "llama model", "model file path not required for lms-only")
 
     srv = cfg_mod.env("LLAMA_SERVER") or str(cfg_mod.data_dir() / "bin" / "llama-server")
     if Path(srv).exists():
-        print(f"  {GREEN('ok')}    server     {srv}")
+        _doctor_row("ok", "llama-server", str(srv))
+    elif uses_llama:
+        _doctor_row("warn", "llama-server",
+                    "not found -- falling back to llama-cli one-shot mode")
     else:
-        print(f"  {YELLOW('warn')}  server     not found -- falling back to slow one-shot mode")
+        _doctor_row("skip", "llama-server", "not needed for lms-only")
 
-    cli = cfg_mod.find_llama_cli()
-    print(f"  {GREEN('ok') if cli else RED('FAIL')}    cli        {cli or 'not found'}")
-    ok = ok and bool(cli or Path(srv).exists())
+    cli_bin = cfg_mod.find_llama_cli()
+    if uses_llama:
+        if cli_bin:
+            _doctor_row("ok", "llama-cli", str(cli_bin))
+        else:
+            _doctor_row("FAIL", "llama-cli", "not found")
+        ok = ok and bool(cli_bin or Path(srv).exists())
+    else:
+        _doctor_row("skip", "llama-cli", "not needed for lms-only")
+
+    lms_key = None
+    lms_loaded = False
+    if uses_lms or cfg.get("lms_path"):
+        lp = cfg.get("lms_path")
+        if lp and Path(lp).is_file():
+            _doctor_row("ok", "lms", str(lp))
+            try:
+                lms_key = lms_backend.resolve_model_key(cfg, Path(lp))
+                lms_loaded = lms_backend.is_loaded(Path(lp), lms_key)
+                _doctor_row("ok", "lms model", lms_key)
+            except lms_backend.LmsError as e:
+                _doctor_row("FAIL", "lms model", str(e))
+                if uses_lms:
+                    ok = False
+        else:
+            _doctor_row("FAIL", "lms",
+                        f"{lp or 'lms_path not set'} -- re-run setup")
+            if uses_lms:
+                ok = False
+    else:
+        found = lms_backend.find_lms()
+        if found:
+            _doctor_row("info", "lms",
+                        f"on PATH ({found}); not configured (run setup to enable)")
 
     bundled = Path(__file__).resolve().parent.parent.parent / "runtime" / "lib"
-    print(f"  {'ok' if bundled.is_dir() else 'warn'}    libs       "
-          f"{bundled if bundled.is_dir() else 'using system libstdc++'}")
+    if bundled.is_dir():
+        _doctor_row("ok", "libs", str(bundled))
+    else:
+        _doctor_row("warn", "libs", "using system libstdc++")
 
-    port = engine.running_port()
-    where = f"listening on {port}" if port else "not running"
-    print(f"  {'ok' if port else 'idle'}  server pid {where}")
-    print(f"  info  threads    {cfg_mod.resolve_threads(cfg)} (of {os.cpu_count()} cores)")
-    print(f"  info  config     {cfg_mod.config_path()}")
+    # Only probe the configured backend. For lms this is "model in memory"
+    # via `lms ps` -- not `lms server status` (the optional HTTP API server).
+    if uses_lms:
+        if lms_key and lms_loaded:
+            _doctor_row("ok", "lms load",
+                        f"model loaded in memory ({lms_key})")
+        elif lms_key:
+            _doctor_row("idle", "lms load",
+                        f"model not loaded in memory ({lms_key})")
+        else:
+            _doctor_row("idle", "lms load", "model not loaded in memory")
+    else:
+        # llama backend (or legacy auto): whatisit's own llama-server only.
+        port = engine.running_port()
+        if port:
+            _doctor_row("ok", "llama run", f"llama-server running (port {port})")
+        else:
+            _doctor_row("idle", "llama run", "llama-server not running")
+
+    nthreads = cfg_mod.resolve_threads(cfg)
+    ncores = os.cpu_count()
+    if uses_lms:
+        _doctor_row("info", "threads",
+                    f"{nthreads} (of {ncores} cores; llama.cpp setting, unused with lms)")
+    else:
+        _doctor_row("info", "threads",
+                    f"{nthreads} (of {ncores} cores; llama.cpp decode)")
+    _doctor_row("info", "config", str(cfg_mod.config_path()))
 
     # Both directories present means the one-time move was skipped rather than
     # run: it never overwrites. Only worth saying here, where someone is
@@ -540,14 +767,28 @@ def cmd_doctor(args, cfg: dict) -> int:
         legacy = cfg_mod.legacy_dir(kind)
         current = cfg_mod.config_dir() if kind == "config" else cfg_mod.data_dir()
         if legacy.is_dir() and current.is_dir():
-            print(f"  {YELLOW('warn')}  {kind:<10} {legacy} also exists and is unused; "
-                  f"{current} is the live one")
+            _doctor_row("warn", kind,
+                        f"{legacy} also exists and is unused; {current} is the live one")
     print(f"\n{GREEN('All good.') if ok else RED('Not ready.')}")
     return 0 if ok else 1
 
 
 def cmd_stop(args, cfg: dict) -> int:
-    print("whatisit: server stopped." if engine.stop_server() else "whatisit: no server running.")
+    stopped = engine.stop_server()
+    if stopped:
+        print("whatisit: llama-server stopped.")
+    else:
+        print("whatisit: llama-server was not running.")
+    if cfg.get("lms_path"):
+        try:
+            if lms_backend.unload_nl2sh(cfg):
+                print("whatisit: LM Studio (lms): unloaded nl2sh model "
+                      "(LM Studio app left running).")
+            else:
+                print("whatisit: LM Studio (lms): nl2sh model was not loaded.")
+        except lms_backend.LmsError as e:
+            print(f"whatisit: LM Studio (lms) unload failed: {e}", file=sys.stderr)
+            return 1
     return 0
 
 
@@ -592,11 +833,11 @@ def build_parser() -> argparse.ArgumentParser:
                     help="print only the bare command, for $(...) use")
     ap.add_argument("-t", "--timing", action="store_true", help="report latency")
     ap.add_argument("--oneshot", action="store_true",
-                    help="bypass the resident server (slower; for debugging)")
+                    help="bypass llama-server; use llama-cli one-shot (slower; debug)")
 
     sub = ap.add_subparsers(dest="sub")
-    s = sub.add_parser("setup", help="first-run setup: fetch the runtime and model")
-    s.add_argument("--model", help="path to a GGUF model you already have")
+    s = sub.add_parser("setup", help="first-run setup: llama.cpp and/or LM Studio (lms)")
+    s.add_argument("--model", help="path to a GGUF model you already have (llama.cpp)")
     s.add_argument("--bin-dir", help="directory containing llama-server / llama-cli")
     s.add_argument("--copy", action="store_true", help="copy the model instead of symlinking")
     s.add_argument("--auto", action="store_true",
@@ -614,7 +855,10 @@ def build_parser() -> argparse.ArgumentParser:
     s.set_defaults(func=cmd_setup)
 
     sub.add_parser("doctor", help="check the installation").set_defaults(func=cmd_doctor)
-    sub.add_parser("stop", help="stop the resident model server").set_defaults(func=cmd_stop)
+    sub.add_parser(
+        "stop",
+        help="stop llama-server and/or unload the nl2sh model in LM Studio",
+    ).set_defaults(func=cmd_stop)
     c = sub.add_parser("config", help="show or change settings")
     c.add_argument("--set", nargs="+", metavar="K=V")
     c.set_defaults(func=cmd_config)

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -33,6 +33,10 @@ DEFAULTS = {
     # Serve over a TCP port instead of a UNIX socket. Set by `setup` when it
     # installs a runtime whose llama-server cannot bind a socket path.
     "force_tcp": False,
+    # Backend: "llama" | "lms" (exactly one). Absent backend_primary => legacy
+    # server/oneshot only (no lms). Written by `whatisit setup`.
+    # Optional keys omitted from defaults: backend_primary, lms_path, lms_model,
+    # lms_ttl.
 }
 
 
@@ -116,13 +120,15 @@ def save_config(cfg: dict) -> Path:
     # Create with 0600 from the start rather than write-then-chmod: the latter
     # leaves a window where the file sits at the umask default -- group-readable
     # on the shared-NFS-home clusters this targets -- readable by a co-tenant.
-    if os.name == 'nt':
-        fd = os.open(str(p), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    else:
-        fd = os.open(str(p), os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    # O_NOFOLLOW is POSIX-only; Windows has no equivalent flag on os.open.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if os.name != "nt":
+        flags |= os.O_NOFOLLOW
+    fd = os.open(str(p), flags, 0o600)
     # The 0o600 above applies only at CREATION; a pre-existing file keeps
     # whatever mode it had. fchmod on the open fd closes that gap, race-free
-    # because it acts on the fd rather than the path.
+    # because it acts on the fd rather than the path. AttributeError: fchmod
+    # is absent on Windows before Python 3.13.
     try:
         os.fchmod(fd, 0o600)
     except (OSError, AttributeError):

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -28,8 +28,7 @@ import urllib.request
 from pathlib import Path
 
 from . import config as cfg_mod
-from . import hostctx
-from . import lms_backend
+from . import hostctx, lms_backend
 from .extract import extract
 
 HOST = "127.0.0.1"
@@ -420,7 +419,8 @@ def _find_server_bin(cfg: dict) -> Path | None:
     return None
 
 
-def _query_lms(cfg: dict, user_msg: str, n: int, system: str | None) -> list[tuple[str, str | None]]:
+def _query_lms(cfg: dict, user_msg: str, n: int, system: str | None) -> \
+        list[tuple[str, str | None]]:
     """n one-shot lms chat calls. finish_reason is always treated as stop."""
     out = []
     for _ in range(max(1, n)):

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from . import config as cfg_mod
 from . import hostctx
+from . import lms_backend
 from .extract import extract
 
 HOST = "127.0.0.1"
@@ -297,7 +298,7 @@ def start_server(model: Path, server_bin: Path, threads: int,
         _write_private(_port_file(), str(port))
 
     if not quiet:
-        print("whatisit: loading model into memory (first run only)...",
+        print("whatisit: starting llama-server (loading model, first run only)...",
               file=sys.stderr, end="", flush=True)
     deadline = time.time() + wait
     while time.time() < deadline:
@@ -360,7 +361,8 @@ def _query_oneshot(model: Path, cli_bin: Path, prompt: str, cfg: dict, threads: 
            "-st", "--no-display-prompt", "--no-warmup",
            "--temp", str(cfg.get("temperature", 0.0)),
            "-n", str(cfg.get("max_tokens", 64)), "-t", str(threads)]
-    p = subprocess.run(cmd, capture_output=True, text=True, env=_runtime_env(), timeout=300)
+    p = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8",
+                       errors="replace", env=_runtime_env(), timeout=300)
     if p.returncode != 0:
         raise RuntimeError(f"llama-cli rc={p.returncode}: {p.stderr[-400:]}")
     # one-shot mode gives no finish_reason; treat as unknown
@@ -407,42 +409,44 @@ def looks_degenerate(cmd: str, min_repeats: int = 4) -> bool:
     return bool(counts) and counts.most_common(1)[0][1] >= min_repeats
 
 
-def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
-             quiet: bool = False) -> tuple[list[str], float, str]:
-    """Return (commands, elapsed_seconds, mode). Commands are already extracted."""
+def _find_server_bin(cfg: dict) -> Path | None:
+    sb = cfg_mod.env("LLAMA_SERVER")
+    if sb and Path(sb).exists():
+        return Path(sb)
+    if (c := cfg_mod.data_dir() / "bin" / "llama-server").exists():
+        return c
+    if (c := Path(cfg.get("llama_server", "/nonexistent"))).exists():
+        return c
+    return None
+
+
+def _query_lms(cfg: dict, user_msg: str, n: int, system: str | None) -> list[tuple[str, str | None]]:
+    """n one-shot lms chat calls. finish_reason is always treated as stop."""
+    out = []
+    for _ in range(max(1, n)):
+        text = lms_backend.chat(cfg, system or cfg_mod.SYSTEM_PROMPT, user_msg)
+        out.append((text, "stop"))
+    return out
+
+
+def _generate_llama(prompt_user: str, cfg: dict, n: int, force_oneshot: bool,
+                    quiet: bool, system: str | None) -> tuple[list[tuple[str, str | None]], str]:
     model = cfg_mod.find_model()
     if model is None:
         raise FileNotFoundError("no model found -- run `whatisit setup`")
     threads = cfg_mod.resolve_threads(cfg)
-
-    server_bin = None
-    if not force_oneshot:
-        sb = cfg_mod.env("LLAMA_SERVER")
-        if sb and Path(sb).exists():
-            server_bin = Path(sb)
-        elif (c := cfg_mod.data_dir() / "bin" / "llama-server").exists():
-            server_bin = c
-        elif (c := Path(cfg.get("llama_server", "/nonexistent"))).exists():
-            server_bin = c
-
-    # Host context defaults ON: it is prefix-cached, so it costs one-time
-    # prefill rather than per-query latency, and it removed a whole class of
-    # placeholder / wrong-tool failures. cfg["host_context"]=false disables it.
-    system, user_msg = hostctx.build(prompt, enabled=cfg.get("host_context", True))
-
-    t0 = time.time()
+    server_bin = None if force_oneshot else _find_server_bin(cfg)
     if server_bin is not None:
         port = start_server(model, server_bin, threads, quiet=quiet)
-        raws = _query_server(port, user_msg, cfg, n, system=system)
-        mode = "server"
-    else:
-        cli = cfg_mod.find_llama_cli()
-        if cli is None:
-            raise FileNotFoundError(
-                "neither llama-server nor llama-cli found -- run `whatisit doctor`")
-        raws = _query_oneshot(model, cli, user_msg, cfg, threads, system=system)
-        mode = "oneshot"
+        return _query_server(port, prompt_user, cfg, n, system=system), "server"
+    cli = cfg_mod.find_llama_cli()
+    if cli is None:
+        raise FileNotFoundError(
+            "neither llama-server nor llama-cli found -- run `whatisit doctor`")
+    return _query_oneshot(model, cli, prompt_user, cfg, threads, system=system), "oneshot"
 
+
+def _finalize_cmds(raws: list[tuple[str, str | None]]) -> list[str]:
     cmds, seen = [], set()
     for raw, finish in raws:
         c = extract(raw)
@@ -457,4 +461,28 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
             continue
         seen.add(c)
         cmds.append(c)
-    return cmds, time.time() - t0, mode
+    return cmds
+
+
+def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
+             quiet: bool = False) -> tuple[list[str], float, str]:
+    """Return (commands, elapsed_seconds, mode). Commands are already extracted."""
+    # Host context defaults ON: it is prefix-cached, so it costs one-time
+    # prefill rather than per-query latency, and it removed a whole class of
+    # placeholder / wrong-tool failures. cfg["host_context"]=false disables it.
+    system, user_msg = hostctx.build(prompt, enabled=cfg.get("host_context", True))
+
+    primary = cfg.get("backend_primary")
+    t0 = time.time()
+
+    # Legacy: no backend_primary => server then oneshot only (never lms).
+    if not primary or primary == "llama":
+        raws, mode = _generate_llama(user_msg, cfg, n, force_oneshot, quiet, system)
+        return _finalize_cmds(raws), time.time() - t0, mode
+
+    if primary == "lms":
+        raws = _query_lms(cfg, user_msg, n, system)
+        return _finalize_cmds(raws), time.time() - t0, "lms"
+
+    raise ValueError(f"unknown backend {primary!r} -- expected 'llama' or 'lms'")
+

--- a/whatisit_pkg/whatisit/hostctx.py
+++ b/whatisit_pkg/whatisit/hostctx.py
@@ -191,12 +191,14 @@ def _git_state(cwd: Path) -> str:
         return ""
     try:
         r = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=str(cwd),
-                           capture_output=True, text=True, timeout=1.5)
+                           capture_output=True, text=True, encoding="utf-8",
+                           errors="replace", timeout=1.5)
         if r.returncode != 0:
             return ""
         branch = r.stdout.strip()
         s = subprocess.run(["git", "status", "--porcelain"], cwd=str(cwd),
-                           capture_output=True, text=True, timeout=1.5)
+                           capture_output=True, text=True, encoding="utf-8",
+                           errors="replace", timeout=1.5)
         dirty = "dirty" if s.stdout.strip() else "clean"
         return f"It is a git repo on branch {branch}, working tree {dirty}."
     except (subprocess.TimeoutExpired, OSError):

--- a/whatisit_pkg/whatisit/lms_backend.py
+++ b/whatisit_pkg/whatisit/lms_backend.py
@@ -1,0 +1,198 @@
+"""LM Studio CLI (`lms`) backend.
+
+Setup stores an absolute path to the `lms` binary and optional model pin.
+Runtime never downloads models; it only ls / ps / load / chat / unload.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from . import config as cfg_mod
+
+NL2SH_PREFIX = "nl2sh"
+HF_MODELS = "https://huggingface.co/ThorOdinson246"
+
+
+class LmsError(Exception):
+    """User-facing failure talking to the lms CLI or resolving its model."""
+
+
+class LmsUnavailable(LmsError):
+    """Backend cannot run (binary missing, model not on disk, load failed)."""
+
+
+def find_lms() -> Path | None:
+    """Resolve `lms` on PATH to an absolute path, or None."""
+    w = shutil.which("lms")
+    return Path(w).resolve() if w else None
+
+
+def lms_path(cfg: dict) -> Path:
+    raw = cfg.get("lms_path")
+    if not raw:
+        raise LmsUnavailable("lms_path not set -- run `whatisit setup`")
+    p = Path(raw)
+    if not p.is_file():
+        raise LmsUnavailable(f"lms_path not found: {p} -- re-run `whatisit setup`")
+    return p
+
+
+def _run(lms: Path, args: list[str], timeout: float = 120.0) -> subprocess.CompletedProcess:
+    try:
+        # Always decode as UTF-8. On Windows, text=True alone uses the active
+        # code page (often cp1252), and lms status/spinners emit bytes that
+        # crash the stdout reader thread mid-flight.
+        return subprocess.run(
+            [str(lms), *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except FileNotFoundError as e:
+        raise LmsUnavailable(f"cannot execute lms at {lms}: {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise LmsError(f"lms {' '.join(args)} timed out after {timeout:.0f}s") from e
+
+
+def _run_json(lms: Path, args: list[str], timeout: float = 60.0) -> list | dict:
+    p = _run(lms, args, timeout=timeout)
+    if p.returncode != 0:
+        err = (p.stderr or p.stdout or "").strip()
+        raise LmsUnavailable(f"lms {' '.join(args)} failed (rc={p.returncode}): {err[-400:]}")
+    text = (p.stdout or "").strip()
+    if not text:
+        return []
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise LmsError(f"lms {' '.join(args)} returned non-JSON: {text[:200]!r}") from e
+
+
+def list_models(lms: Path) -> list[dict]:
+    data = _run_json(lms, ["ls", "--json"])
+    if not isinstance(data, list):
+        raise LmsError("lms ls --json: expected a JSON array")
+    return data
+
+
+def loaded_models(lms: Path) -> list[dict]:
+    data = _run_json(lms, ["ps", "--json"])
+    if not isinstance(data, list):
+        raise LmsError("lms ps --json: expected a JSON array")
+    return data
+
+
+def nl2sh_keys(models: list[dict]) -> list[str]:
+    keys = []
+    for m in models:
+        if m.get("type") and m.get("type") != "llm":
+            continue
+        key = m.get("modelKey") or ""
+        if key.startswith(NL2SH_PREFIX):
+            keys.append(key)
+    return sorted(set(keys))
+
+
+def resolve_model_key(cfg: dict, lms: Path | None = None) -> str:
+    """Pinned lms_model, else unique nl2sh* key from ls, else raise."""
+    pin = cfg.get("lms_model")
+    if pin:
+        return str(pin)
+    lms = lms or lms_path(cfg)
+    keys = nl2sh_keys(list_models(lms))
+    if len(keys) == 1:
+        return keys[0]
+    if not keys:
+        raise LmsUnavailable(
+            "no nl2sh model in LM Studio -- during setup, download one with:\n"
+            f"  lms get {HF_MODELS}/nl2sh-<version> -y\n"
+            f"  see {HF_MODELS}"
+        )
+    raise LmsError(
+        "multiple nl2sh models in LM Studio; pin one with "
+        "`whatisit config --set lms_model=<key>`:\n  " + "\n  ".join(keys)
+    )
+
+
+def is_loaded(lms: Path, key: str) -> bool:
+    for m in loaded_models(lms):
+        if m.get("modelKey") == key or m.get("identifier") == key:
+            return True
+    return False
+
+
+def ensure_loaded(cfg: dict, key: str | None = None) -> str:
+    """Load model if needed. Returns the model key used."""
+    lms = lms_path(cfg)
+    key = key or resolve_model_key(cfg, lms)
+    disk_keys = {m.get("modelKey") for m in list_models(lms)}
+    if key not in disk_keys:
+        raise LmsUnavailable(
+            f"lms model {key!r} not in `lms ls` -- run setup / lms get"
+        )
+    if is_loaded(lms, key):
+        return key
+    args = ["load", key, "-y"]
+    ttl = cfg.get("lms_ttl")
+    if ttl is not None and ttl != "" and int(ttl) > 0:
+        args.extend(["--ttl", str(int(ttl))])
+    p = _run(lms, args, timeout=600.0)
+    if p.returncode != 0:
+        err = (p.stderr or p.stdout or "").strip()
+        raise LmsUnavailable(f"lms load {key} failed (rc={p.returncode}): {err[-400:]}")
+    return key
+
+
+def chat(cfg: dict, system: str, prompt: str, key: str | None = None,
+         timeout: float = 300.0) -> str:
+    """One-shot chat; returns assistant text on stdout."""
+    lms = lms_path(cfg)
+    key = ensure_loaded(cfg, key)
+    args = [
+        "chat", key,
+        "--dont-fetch-catalog", "-y",
+        "-s", system or cfg_mod.SYSTEM_PROMPT,
+        "-p", prompt,
+    ]
+    p = _run(lms, args, timeout=timeout)
+    if p.returncode != 0:
+        err = (p.stderr or p.stdout or "").strip()
+        raise LmsError(f"lms chat failed (rc={p.returncode}): {err[-400:]}")
+    return (p.stdout or "").strip()
+
+
+def unload_nl2sh(cfg: dict) -> bool:
+    """Unload the configured/discovered nl2sh model if loaded. True if unloaded."""
+    if not cfg.get("lms_path"):
+        return False
+    try:
+        lms = lms_path(cfg)
+        key = resolve_model_key(cfg, lms)
+    except LmsError:
+        return False
+    if not is_loaded(lms, key):
+        return False
+    # Prefer identifier from ps when present (unload arg is identifier).
+    ident = key
+    for m in loaded_models(lms):
+        if m.get("modelKey") == key or m.get("identifier") == key:
+            ident = m.get("identifier") or key
+            break
+    p = _run(lms, ["unload", ident], timeout=60.0)
+    if p.returncode != 0:
+        err = (p.stderr or p.stdout or "").strip()
+        raise LmsError(f"lms unload {ident} failed (rc={p.returncode}): {err[-400:]}")
+    return True
+
+
+def model_get_instructions() -> str:
+    return (
+        f"Download an nl2sh model into LM Studio, then re-run setup:\n"
+        f"  see {HF_MODELS}\n"
+        f"  lms get {HF_MODELS}/nl2sh-<version> -y"
+    )


### PR DESCRIPTION
## What does this change do, and why?

### Add LM Studio CLI backend
A second inference path beside llama.cpp, via the `lms` _CLI only_ (no LM Studio HTTP API).
This was tested on Windows but especially since it only uses the lms command to do everything it should work anywhere that has the lms command in the path during setup.

#### Behaviour rules (locked in)
- One backend only — no primary/fallback dual stack
- Model for lms: lms ls keys starting with nl2sh; pin with lms_model if several
- --auto / no TTY + both present → llama.cpp
- Chat: lms chat --dont-fetch-catalog -y -s … -p …
- Load: lms load … -y (+ --ttl only if lms_ttl set)
- setup looks for `lms` command in it's path when run and "enshrines" it in the config as an absolute path to help prevent later path trickery

#### UX polish
- Messages distinguish llama.cpp vs LM Studio (lms)
- Doctor table alignment (status | field | detail)
- Runtime lines name which stack was checked

#### Intentionally not added
- Auto lms get during generate - if the model isn't already downloaded in LMStudio it will just tell you how to do it
- LM Studio OpenAI/HTTP API
- Dual-backend fallback
- Windows as a fully “supported” product platform in classifiers (lms is just a useful backend there)

## How was it tested?

ONLY tested on Windows so far. Seems like it should work fine with any other OS with LM Studio CLI installed, since it relies entirely on `lms` cli commands, but hasn't actually been tested as of yet.

- [x] `pytest -q` passes locally (`whatisit_pkg/`)
- [x] `ruff check .` is clean (or new findings are explained below)
- [x] If this touches `safety.py` or `extract.py`: no case was removed or
      weakened in `tests/test_safety.py` / `tests/test_extract.py` -- only
      added to

## Anything reviewers should look at closely?

I think it's all pretty uncontroversial. I can't really think of any difficult tradeoff decisions that were needed; I pretty much went with status quo + add LMStudio support.