### PR TITLE
feat: refuse -e in windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ campaign/
 # Local-only git helpers. Referenced by nothing that ships.
 .gitmessage
 hooks/
+
+# pip build
+whatisit_pkg/build/

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ hooks/
 
 # pip build
 whatisit_pkg/build/
+whatisit_pkg/dist/

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -11,6 +11,8 @@ These cover cases that were REAL bugs found by typing realistic requests:
 None of this starts a server or touches the network: engine.generate is
 monkeypatched wherever cmd_query would otherwise call into it.
 """
+import os
+
 import pytest
 
 from whatisit import cli
@@ -144,6 +146,15 @@ class TestCmdQueryQuietDangerRefusal:
         rc = cli.main(["-q"])
         assert rc == 0  # falls through to help, per main()'s "no words" branch
 
+    def test_refuse_execute_in_windows(self, monkeypatch, capsys):
+        monkeypatch.setattr(os, "name", "nt")
+        monkeypatch.setattr(
+            cli.engine, "generate",
+            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False:
+                (["ls -la"], 0.01, "server"))
+        rc = cli.main(["-e", "list", "files"])
+        assert rc == 7
+        assert "disabled" in capsys.readouterr().out
 
 # ------------------------------------------------------------------ parser
 
@@ -201,3 +212,4 @@ def test_subcommand_word_inside_a_question_stays_a_question():
     a = cli.QueryArgs(["how", "do", "I", "stop", "a", "stuck", "process"])
     assert a.words[0] == "how"
     assert a.stray_flags == []
+

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -154,7 +154,7 @@ class TestCmdQueryQuietDangerRefusal:
                 (["ls -la"], 0.01, "server"))
         rc = cli.main(["-e", "list", "files"])
         assert rc == 7
-        assert "disabled" in capsys.readouterr().out
+        assert "disabled" in capsys.readouterr().err
 
 # ------------------------------------------------------------------ parser
 

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -156,6 +156,18 @@ class TestCmdQueryQuietDangerRefusal:
         assert rc == 7
         assert "disabled" in capsys.readouterr().err
 
+    def test_execute_is_not_refused_off_windows(self, monkeypatch, capsys):
+        # Without this, a _is_windows() stuck at True would pass the test above
+        # and silently disable -e everywhere.
+        monkeypatch.setattr(cli, "_is_windows", lambda: False)
+        monkeypatch.setattr(
+            cli.engine, "generate",
+            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False:
+                (["ls -la"], 0.01, "server"))
+        rc = cli.main(["-e", "list", "files"])
+        assert rc != 7
+        assert "disabled" not in capsys.readouterr().err
+
 # ------------------------------------------------------------------ parser
 
 class TestBuildParser:

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -11,8 +11,6 @@ These cover cases that were REAL bugs found by typing realistic requests:
 None of this starts a server or touches the network: engine.generate is
 monkeypatched wherever cmd_query would otherwise call into it.
 """
-import os
-
 import pytest
 
 from whatisit import cli
@@ -147,7 +145,9 @@ class TestCmdQueryQuietDangerRefusal:
         assert rc == 0  # falls through to help, per main()'s "no words" branch
 
     def test_refuse_execute_in_windows(self, monkeypatch, capsys):
-        monkeypatch.setattr(os, "name", "nt")
+        # Patch the helper, not os.name: setting os.name="nt" on Linux makes
+        # Path.home() (via load_config in main) raise RuntimeError.
+        monkeypatch.setattr(cli, "_is_windows", lambda: True)
         monkeypatch.setattr(
             cli.engine, "generate",
             lambda prompt, cfg, n=1, force_oneshot=False, quiet=False:

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -25,6 +25,16 @@ from .safety import check
 _TTY = sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
 
 
+def _is_windows() -> bool:
+    """Isolated so tests can fake Windows without rewriting global os.name.
+
+    Monkeypatching os.name="nt" on Linux breaks pathlib.Path.home() (used by
+    config_dir during main()), which then raises RuntimeError looking for a
+    Windows home directory that does not exist on the CI host.
+    """
+    return os.name == "nt"
+
+
 def _c(code: str, s: str) -> str:
     return f"\033[{code}m{s}\033[0m" if _TTY else s
 
@@ -168,7 +178,7 @@ def cmd_query(args, cfg: dict) -> int:
     if not args.execute:
         return 0
 
-    if os.name == 'nt':
+    if _is_windows():
         print("warning: --execute is disabled on windows for safety reasons (no classifier)")
         return 7
 

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -168,6 +168,10 @@ def cmd_query(args, cfg: dict) -> int:
     if not args.execute:
         return 0
 
+    if os.name == 'nt':
+        print("warning: --execute is disabled on windows for safety reasons (no classifier)")
+        return 7
+
     # ---- execution path ----
     # With several candidates on screen, do NOT assume #1. The numbering only
     # ranks confidence, and #1 is the greedy answer rather than a verified one;

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -179,7 +179,7 @@ def cmd_query(args, cfg: dict) -> int:
         return 0
 
     if _is_windows():
-        print("warning: --execute is disabled on windows for safety reasons (no classifier)")
+        print("whatisit: --execute is disabled on Windows", file=sys.stderr)
         return 7
 
     # ---- execution path ----


### PR DESCRIPTION
Because -e is not safe yet, no classifier.

## What does this change do, and why?

return 7 and print warning if -e is specified and os.name == 'nt'

## How was it tested?

- [x] `pytest -q` passes locally (`whatisit_pkg/`)
- [x] `ruff check .` is clean (or new findings are explained below)
- [x] If this touches `safety.py` or `extract.py`: no case was removed or
      weakened in `tests/test_safety.py` / `tests/test_extract.py` -- only
      added to

## Anything reviewers should look at closely?

- See if my unit test is sufficient.
- Consider adding functions similar to output(), warn() and error() functions to route messages to stdout and stderr according to type.