### PR TITLE
feat: add support for OpenAI-compatible remote endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # whatisit-nl2sh
 
-Ask for a shell command in plain English. Runs on your own machine, on CPU.
-No GPU, no API key, no network. Answers in about a second.
+Ask for a shell command in plain English. Local by default, on CPU. No GPU, no
+API key, no network. Answers in about a second. Optionally, it can also ask any
+OpenAI-compatible model service (OpenAI, Ollama, a remote or LAN `llama.cpp`, a
+compatible gateway) instead — see [Remote endpoints](#remote-endpoints).
 
 ![whatisit in use](whatisit.gif)
 
@@ -123,6 +125,50 @@ whatisit -e remove every .pyc file under this tree
 
 `whatisit stop` shuts down the resident model server. `whatisit config --set threads=4`
 changes settings.
+
+## Remote endpoints
+
+By default everything runs locally. If you want to point whatisit at an
+OpenAI-compatible endpoint instead — a hosted API, an Ollama server, or a
+`llama.cpp` server you already have running — set three things:
+
+```bash
+whatisit config --set \
+  openai_base_url=http://127.0.0.1:8080/v1 \
+  openai_model=your-model-name
+```
+
+* `openai_base_url` is the endpoint's base URL. It must be `http://` or
+  `https://`. Either `.../v1` or the full `.../v1/chat/completions` route works.
+* `openai_model` is the model name the endpoint should generate with (list them
+  with `curl $BASE/models`). This is required; whatisit will not guess one.
+* `openai_api_key` is the bearer token. It's optional — a LAN `llama.cpp` server
+  usually needs none. Prefer the environment over the config file so the secret
+  stays off disk:
+
+```bash
+export WHATISIT_OPENAI_API_KEY=sk-...
+```
+
+Whenever a base URL is configured, whatisit uses the remote backend and no
+longer needs a local model or `llama.cpp` at all. `-n N`, `-q`, `-e` and the
+safety checks all work identically. `whatisit doctor` reports the remote
+backend. Set `openai_base_url=` back to empty (or unset it) to return to the
+fully-local mode.
+
+A few extra knobs: `openai_timeout` (default 120 s) and `openai_max_tokens`
+(default 512). The token budget matters for reasoning models, which "think"
+inside the generation before emitting the command — the local 64-token default
+is too small for them, which is why remote mode defaults higher.
+
+### Privacy
+
+Remote mode sends your request (and the host context, if you've enabled
+`host_context`) to whatever the endpoint is. That is the one thing this tool
+otherwise promises never to do, so it is strictly opt-in and whatisit prints a
+warning to stderr on the first remote call. Don't type secrets into the prompt
+against a shared endpoint. Prefer an `https://` endpoint; over plain `http://`
+the request (and your key, if one is set) travels unencrypted.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # whatisit-nl2sh
 
-Ask for a shell command in plain English. Local by default, on CPU. No GPU, no
-API key, no network. Answers in about a second. Optionally, it can also ask any
-OpenAI-compatible model service (OpenAI, Ollama, a remote or LAN `llama.cpp`, a
-compatible gateway) instead — see [Remote endpoints](#remote-endpoints).
+Ask for a shell command in plain English. Runs on your own machine, on CPU.
+No GPU, no API key, no network. Answers in about a second.
 
 ![whatisit in use](whatisit.gif)
 
@@ -128,47 +126,19 @@ changes settings.
 
 ## Remote endpoints
 
-By default everything runs locally. If you want to point whatisit at an
-OpenAI-compatible endpoint instead — a hosted API, an Ollama server, or a
-`llama.cpp` server you already have running — set three things:
+To use a hosted API, Ollama, or a `llama.cpp` server you already have running:
 
 ```bash
-whatisit config --set \
-  openai_base_url=http://127.0.0.1:8080/v1 \
-  openai_model=your-model-name
+whatisit config --set openai_base_url=http://127.0.0.1:8080/v1 openai_model=your-model-name
+export WHATISIT_OPENAI_API_KEY=sk-...   # optional; prefer env over the config file
 ```
 
-* `openai_base_url` is the endpoint's base URL. It must be `http://` or
-  `https://`. Either `.../v1` or the full `.../v1/chat/completions` route works.
-* `openai_model` is the model name the endpoint should generate with (list them
-  with `curl $BASE/models`). This is required; whatisit will not guess one.
-* `openai_api_key` is the bearer token. It's optional — a LAN `llama.cpp` server
-  usually needs none. Prefer the environment over the config file so the secret
-  stays off disk:
+`openai_model` is required. Empty `WHATISIT_OPENAI_BASE_URL=` (or
+`openai_base_url=`) returns to local mode. Extra knobs: `openai_timeout`
+(default 120 s) and `openai_max_tokens` (default 512, for reasoning models).
 
-```bash
-export WHATISIT_OPENAI_API_KEY=sk-...
-```
-
-Whenever a base URL is configured, whatisit uses the remote backend and no
-longer needs a local model or `llama.cpp` at all. `-n N`, `-q`, `-e` and the
-safety checks all work identically. `whatisit doctor` reports the remote
-backend. Set `openai_base_url=` back to empty (or unset it) to return to the
-fully-local mode.
-
-A few extra knobs: `openai_timeout` (default 120 s) and `openai_max_tokens`
-(default 512). The token budget matters for reasoning models, which "think"
-inside the generation before emitting the command — the local 64-token default
-is too small for them, which is why remote mode defaults higher.
-
-### Privacy
-
-Remote mode sends your request (and the host context, if you've enabled
-`host_context`) to whatever the endpoint is. That is the one thing this tool
-otherwise promises never to do, so it is strictly opt-in and whatisit prints a
-warning to stderr on the first remote call. Don't type secrets into the prompt
-against a shared endpoint. Prefer an `https://` endpoint; over plain `http://`
-the request (and your key, if one is set) travels unencrypted.
+This sends your request off the machine, so it is opt-in and whatisit prints a
+warning to stderr on every remote call. Prefer `https://`.
 
 ## How it works
 

--- a/whatisit_pkg/pyproject.toml
+++ b/whatisit_pkg/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 license = { text = "Apache-2.0" }
 authors = [{ name = "ThorOdinson246", email = "110178596+ThorOdinson246@users.noreply.github.com" }]
 keywords = ["shell", "cli", "llm", "local", "local-first", "privacy", "bash",
-            "command-generation", "llama-cpp", "offline", "whatisit"]
+            "command-generation", "llama-cpp", "offline", "openai", "whatisit"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -225,3 +225,48 @@ def test_subcommand_word_inside_a_question_stays_a_question():
     assert a.words[0] == "how"
     assert a.stray_flags == []
 
+
+class TestRemoteCli:
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+        for suff in ("OPENAI_BASE_URL", "OPENAI_MODEL", "OPENAI_API_KEY"):
+            for pref in ("WHATISIT_", "NL2SH_"):
+                monkeypatch.delenv(pref + suff, raising=False)
+
+    def test_config_redacts_api_key(self, monkeypatch, tmp_path, capsys):
+        self._isolate(monkeypatch, tmp_path)
+        rc = cli.main(["config", "--set",
+                       "openai_base_url=http://h/v1",
+                       "openai_api_key=sk-secret"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "sk-secret" not in out
+        assert "********" in out
+
+    def test_doctor_fails_without_model(self, monkeypatch, tmp_path, capsys):
+        self._isolate(monkeypatch, tmp_path)
+        monkeypatch.setattr(cli.engine, "list_remote_models", lambda remote: [])
+        rc = cli.main(["config", "--set", "openai_base_url=http://h/v1"])
+        assert rc == 0
+        rc = cli.main(["doctor"])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "Not ready" in out
+        assert "not set" in out
+
+    def test_query_warns_on_stderr_only(self, monkeypatch, tmp_path, capsys):
+        self._isolate(monkeypatch, tmp_path)
+        monkeypatch.setenv("WHATISIT_OPENAI_BASE_URL", "http://192.0.2.8/v1")
+        monkeypatch.setenv("WHATISIT_OPENAI_MODEL", "m")
+
+        def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False):
+            return (["ls"], 0.01, "remote")
+
+        monkeypatch.setattr(cli.engine, "generate", fake_generate)
+        rc = cli.main(["-q", "list", "files"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert captured.out.strip() == "ls"
+        assert "leaves this machine" in captured.err
+

--- a/whatisit_pkg/tests/test_config.py
+++ b/whatisit_pkg/tests/test_config.py
@@ -364,3 +364,17 @@ class TestRemoteConfig:
         c = cfg_mod.remote_config({"openai_base_url": "http://h/v1",
                                    "openai_model": "  "})
         assert c["model"] is None
+
+    def test_empty_env_overrides_config_and_goes_local(self, monkeypatch):
+        """WHATISIT_OPENAI_BASE_URL= must not fall through to config.json."""
+        self._clear(monkeypatch)
+        monkeypatch.setenv("WHATISIT_OPENAI_BASE_URL", "")
+        assert cfg_mod.remote_config({"openai_base_url": "http://h/v1",
+                                      "openai_model": "m"}) is None
+
+    def test_empty_env_key_clears_stored_key(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("WHATISIT_OPENAI_API_KEY", "")
+        c = cfg_mod.remote_config({"openai_base_url": "http://h/v1",
+                                   "openai_api_key": "stored"})
+        assert c["api_key"] == ""

--- a/whatisit_pkg/tests/test_config.py
+++ b/whatisit_pkg/tests/test_config.py
@@ -285,3 +285,82 @@ class TestLegacyDirMigration:
 
         msgs = cfg_mod.migrate_legacy_dirs(echo=lambda m: None)
         assert any("no longer resolves" in m for m in msgs)
+
+
+class TestRemoteConfig:
+    """remote_config() resolution: when it activates, env-over-config, secrets."""
+
+    def _clear(self, monkeypatch):
+        _clear_xdg(monkeypatch)
+        for suff in ("OPENAI_BASE_URL", "OPENAI_MODEL", "OPENAI_API_KEY",
+                     "OPENAI_TIMEOUT", "OPENAI_MAX_TOKENS"):
+            for pref in ("WHATISIT_", "NL2SH_"):
+                monkeypatch.delenv(pref + suff, raising=False)
+
+    def test_none_when_no_base_url(self, monkeypatch):
+        self._clear(monkeypatch)
+        assert cfg_mod.remote_config({}) is None
+
+    def test_empty_base_url_means_local(self, monkeypatch):
+        self._clear(monkeypatch)
+        assert cfg_mod.remote_config({"openai_base_url": ""}) is None
+
+    def test_resolves_from_config(self, monkeypatch):
+        self._clear(monkeypatch)
+        c = cfg_mod.remote_config({"openai_base_url": "http://h:1/v1",
+                                   "openai_model": "m",
+                                   "openai_api_key": "k"})
+        assert c["base_url"] == "http://h:1/v1"
+        assert c["model"] == "m"
+        assert c["api_key"] == "k"
+        assert c["max_tokens"] == 512
+        assert c["timeout"] == 120.0
+
+    def test_env_overrides_config(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("WHATISIT_OPENAI_BASE_URL", "http://env:2/v1")
+        monkeypatch.setenv("WHATISIT_OPENAI_MODEL", "env-model")
+        monkeypatch.setenv("WHATISIT_OPENAI_API_KEY", "env-key")
+        c = cfg_mod.remote_config({"openai_base_url": "http://cfg:1/",
+                                   "openai_model": "cfg-model",
+                                   "openai_api_key": "cfg-key"})
+        assert c["base_url"] == "http://env:2/v1"
+        assert c["model"] == "env-model"
+        assert c["api_key"] == "env-key"
+
+    def test_keyless_by_default(self, monkeypatch):
+        self._clear(monkeypatch)
+        c = cfg_mod.remote_config({"openai_base_url": "http://h/v1"})
+        assert c["api_key"] == ""
+        assert c["model"] is None
+
+    def test_timeout_and_max_tokens_overridable(self, monkeypatch):
+        self._clear(monkeypatch)
+        c = cfg_mod.remote_config({"openai_base_url": "http://h/v1",
+                                   "openai_timeout": 30, "openai_max_tokens": 1000})
+        assert c["timeout"] == 30
+        assert c["max_tokens"] == 1000
+
+    def test_env_timeout_precedence(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("WHATISIT_OPENAI_MAX_TOKENS", "256")
+        c = cfg_mod.remote_config({"openai_base_url": "http://h/v1",
+                                   "openai_max_tokens": 999})
+        assert c["max_tokens"] == 256
+
+    def test_garbage_numeric_values_fall_back(self, monkeypatch):
+        self._clear(monkeypatch)
+        c = cfg_mod.remote_config({"openai_base_url": "http://h/v1",
+                                   "openai_timeout": "abc", "openai_max_tokens": []})
+        assert c["timeout"] == 120.0
+        assert c["max_tokens"] == 512
+
+    def test_whitespace_only_base_url_means_local(self, monkeypatch):
+        self._clear(monkeypatch)
+        assert cfg_mod.remote_config({"openai_base_url": "   "}) is None
+
+    def test_whitespace_only_model_is_unset(self, monkeypatch):
+        self._clear(monkeypatch)
+        c = cfg_mod.remote_config({"openai_base_url": "http://h/v1",
+                                   "openai_model": "  "})
+        assert c["model"] is None

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -8,6 +8,8 @@ to exist.
 import os
 import stat
 import sys
+import urllib.error
+import urllib.request
 
 import pytest
 
@@ -235,3 +237,283 @@ class _FakeHostCtx:
     @staticmethod
     def build(prompt, enabled=True, cwd=None):
         return ("SYSTEM PROMPT", prompt)
+
+
+class _FakeResp:
+    """Stand-in for urllib's HTTPResponse: just a callable read()."""
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self._exhausted = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self, size=-1, *a, **k):
+        # One-shot stream, like a real HTTP response body: emit the payload
+        # once, then EOF, so _read_capped()'s read loop terminates.
+        if self._exhausted:
+            return b""
+        self._exhausted = True
+        return self._payload
+
+
+class TestNormalizeEndpoint:
+    def test_trailing_slash_removed(self):
+        assert engine.normalize_endpoint_url("http://h:1/v1/") == "http://h:1/v1"
+
+    def test_full_route_stripped(self):
+        assert (engine.normalize_endpoint_url("http://h:1/v1/chat/completions/") ==
+                "http://h:1/v1")
+
+    def test_preserves_path_prefix(self):
+        assert (engine.normalize_endpoint_url("https://ex.com/llm/v1/") ==
+                "https://ex.com/llm/v1")
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError, match="empty"):
+            engine.normalize_endpoint_url("")
+
+    def test_non_http_rejected(self):
+        with pytest.raises(ValueError, match="http"):
+            engine.normalize_endpoint_url("ftp://h/")
+
+    def test_embedded_credentials_rejected(self):
+        with pytest.raises(ValueError, match="credentials"):
+            engine.normalize_endpoint_url("http://u:p@h/v1")
+
+    def test_fragment_rejected(self):
+        with pytest.raises(ValueError, match="fragment"):
+            engine.normalize_endpoint_url("http://h/v1#frag")
+
+    def test_no_host_rejected(self):
+        with pytest.raises(ValueError, match="no host"):
+            engine.normalize_endpoint_url("http:///v1")
+
+
+class TestParseChoices:
+    def test_ok(self):
+        assert engine._parse_choices(
+            {"choices": [{"message": {"content": "x"}, "finish_reason": "stop"}]}
+        ) == [("x", "stop")]
+
+    def test_missing_choices(self):
+        with pytest.raises(RuntimeError, match="no choices"):
+            engine._parse_choices({})
+
+    def test_non_string_content_skipped(self):
+        r = {"choices": [{"message": {"content": None}},
+                         {"message": {"content": "ok"}, "finish_reason": "stop"}]}
+        assert engine._parse_choices(r) == [("ok", "stop")]
+
+    def test_no_usable_choices(self):
+        with pytest.raises(RuntimeError, match="no usable"):
+            engine._parse_choices({"choices": [{"message": {"content": None}}]})
+
+
+class TestRemotePost:
+    """_remote_post(): the HTTP layer, with urllib fully mocked."""
+
+    def _fake_opener(self, resp):
+        class _Opener:
+            def __init__(self, r):
+                self.r = r
+
+            def open(self, req, **kw):
+                self.req, self.kw = req, kw
+                return self.r
+
+        o = _Opener(resp)
+        return o
+
+    def test_sends_bearer_and_parses(self, monkeypatch):
+        import json
+        payload = json.dumps({"choices": [{"message": {"content": "ls -la"},
+                                            "finish_reason": "stop"}]}).encode()
+        opener = self._fake_opener(_FakeResp(payload))
+        monkeypatch.setattr(urllib.request, "build_opener", lambda *a: opener)
+        out = engine._remote_post("http://h:1/v1/", "m", "secret", {"model": "m"})
+        assert out == [("ls -la", "stop")]
+        req = opener.req
+        assert req.full_url == "http://h:1/v1/chat/completions"
+        assert req.get_method() == "POST"
+        assert req.get_header("Authorization") == "Bearer secret"
+        assert json.loads(req.data)["model"] == "m"
+
+    def test_no_authorization_header_when_keyless(self, monkeypatch):
+        opener = self._fake_opener(_FakeResp(b'{"choices":[]}'))
+        monkeypatch.setattr(urllib.request, "build_opener", lambda *a: opener)
+        with pytest.raises(RuntimeError, match="no usable"):
+            engine._remote_post("http://h:1/v1", "m", "", {})
+        assert opener.req.get_header("Authorization") is None
+
+    def test_http_error_message_no_secret(self, monkeypatch):
+        import urllib.error
+        err = urllib.error.HTTPError("http://h:1/v1/chat/completions", 401,
+                                     "Unauthorized", {}, _FakeResp(b"invalid key"))
+
+        def boom(*a, **k):
+            raise err
+
+        class _Bad:
+            open = staticmethod(boom)
+
+        monkeypatch.setattr(urllib.request, "build_opener", lambda *a: _Bad())
+        with pytest.raises(RuntimeError) as ei:
+            engine._remote_post("http://h:1/v1", "m", "sekrit-key", {})
+        assert "401" in str(ei.value)
+        assert "sekrit-key" not in str(ei.value)
+
+    def test_non_json_response(self, monkeypatch):
+        opener = self._fake_opener(_FakeResp(b"<html>proxy error</html>"))
+        monkeypatch.setattr(urllib.request, "build_opener", lambda *a: opener)
+        with pytest.raises(RuntimeError, match="non-JSON"):
+            engine._remote_post("http://h:1/v1", "m", "", {})
+
+    def test_no_cross_origin_redirect_handler(self):
+        h = engine._NoCrossOriginRedirect()
+        req = urllib.request.Request("http://h:1/v1/chat/completions",
+                                     data=b"{}", method="POST")
+        # Refuses a redirect to a different authority.
+        assert h.redirect_request(req, None, 302, "Found", {},
+                                  "http://evil:9/steal") is None
+
+    def test_list_remote_models(self, monkeypatch):
+        opener = self._fake_opener(_FakeResp(b'{"data":[{"id":"a"},{"id":"b"}]}'))
+        monkeypatch.setattr(urllib.request, "build_opener", lambda *a: opener)
+        names = engine.list_remote_models({"base_url": "http://h:1/v1", "api_key": ""})
+        assert names == ["a", "b"]
+        assert opener.req.full_url == "http://h:1/v1/models"
+        assert opener.req.get_method() == "GET"
+
+
+class TestQueryRemote:
+    REMOTE = {"base_url": "http://h/v1", "model": "m", "api_key": "",
+              "timeout": 120.0, "max_tokens": 512}
+
+    def test_greedy_then_separate_sampled_calls(self, monkeypatch):
+        calls = []
+
+        def fake_post(base, model, key, body, timeout=120.0):
+            calls.append((body.get("temperature"), body.get("n")))
+            return [(f"cmd{len(calls)}", "stop")]
+
+        monkeypatch.setattr(engine, "_remote_post", fake_post)
+        out = engine._query_remote(self.REMOTE, "prompt",
+                                   {"temperature": 0.2}, n=3, system="S")
+        assert [c for c, _ in out] == ["cmd1", "cmd2", "cmd3"]
+        assert calls[0] == (0.2, 1)
+        assert calls[1] == calls[2] == (max(0.6, 0.2), 1)  # never uses n>1
+
+    def test_single_candidate_skips_sampling(self, monkeypatch):
+        calls = []
+
+        def fake_post(*a, **k):
+            calls.append(1)
+            return [("cmd", "stop")]
+
+        monkeypatch.setattr(engine, "_remote_post", fake_post)
+        engine._query_remote(self.REMOTE, "p", {}, n=1, system="S")
+        assert calls == [1]
+
+    def test_sampled_failure_keeps_greedy(self, monkeypatch):
+        state = {"i": 0}
+
+        def fake_post(*a, **k):
+            state["i"] += 1
+            if state["i"] > 1:
+                raise RuntimeError("boom")
+            return [("cmd", "stop")]
+
+        monkeypatch.setattr(engine, "_remote_post", fake_post)
+        out = engine._query_remote(self.REMOTE, "p", {}, n=3, system="S")
+        assert out == [("cmd", "stop")]
+
+    def test_passes_model_max_tokens_and_key(self, monkeypatch):
+        seen = {}
+
+        def fake_post(base, model, key, body, timeout=120.0):
+            seen.update(base=base, model=model, key=key, body=body, to=timeout)
+            return [("c", "stop")]
+
+        monkeypatch.setattr(engine, "_remote_post", fake_post)
+        engine._query_remote({**self.REMOTE, "api_key": "K", "timeout": 30.0,
+                              "max_tokens": 1024}, "p", {}, n=1, system="S")
+        assert seen["model"] == "m" and seen["key"] == "K"
+        assert seen["body"]["model"] == "m"
+        assert seen["body"]["max_tokens"] == 1024
+        assert seen["to"] == 30.0
+
+
+class TestGenerateRemote:
+    def _remote(self, **over):
+        return {"base_url": "http://h/v1", "model": "m", "api_key": "",
+                "timeout": 120.0, "max_tokens": 512, **over}
+
+    def _enable_remote(self, monkeypatch, remote):
+        monkeypatch.setattr(cfg_mod, "remote_config", lambda cfg: remote)
+        monkeypatch.setattr(engine.hostctx, "build",
+                            lambda p, enabled=True, cwd=None: ("SYS", p))
+
+    def test_remote_mode_needs_no_local_model(self, monkeypatch):
+        self._enable_remote(monkeypatch, self._remote())
+        monkeypatch.setattr(cfg_mod, "find_model", lambda: None)
+        monkeypatch.setattr(engine, "_query_remote",
+                            lambda *a, **k: [("ls -la", "stop")])
+        cmds, elapsed, mode = engine.generate("list files", {})
+        assert cmds == ["ls -la"]
+        assert mode == "remote"
+
+    def test_remote_missing_model_raises(self, monkeypatch):
+        self._enable_remote(monkeypatch, self._remote(model=None))
+        with pytest.raises(RuntimeError, match="no model selected"):
+            engine.generate("list files", {})
+
+    def test_remote_oneshot_incompatible(self, monkeypatch):
+        self._enable_remote(monkeypatch, self._remote())
+        with pytest.raises(RuntimeError, match="oneshot"):
+            engine.generate("list files", {}, force_oneshot=True)
+
+    def test_remote_drops_length_finish(self, monkeypatch):
+        self._enable_remote(monkeypatch, self._remote())
+        monkeypatch.setattr(engine, "_query_remote",
+                            lambda *a, **k: [("ls -la", "length"), ("pwd", "stop")])
+        cmds, _, _ = engine.generate("list files", {})
+        assert cmds == ["pwd"]
+
+    def test_remote_dedups_candidates(self, monkeypatch):
+        self._enable_remote(monkeypatch, self._remote())
+        monkeypatch.setattr(engine, "_query_remote",
+                            lambda *a, **k: [("ls", "stop"), ("ls", "stop")])
+        cmds, _, mode = engine.generate("list files", {}, n=2)
+        assert cmds == ["ls"]
+        assert mode == "remote"
+
+
+class TestRemoteWarnings:
+    def test_warns_request_leaves_machine(self):
+        w = engine.remote_warnings({"base_url": "https://api.example.com/v1",
+                                    "api_key": ""})
+        assert any("leaves this machine" in x for x in w)
+
+    def test_http_with_key_warns_cleartext(self):
+        w = engine.remote_warnings({"base_url": "http://remote.example.com/v1",
+                                    "api_key": "k"})
+        assert any("unencrypted" in x for x in w)
+
+    def test_no_warning_for_local_loopback(self):
+        w = engine.remote_warnings({"base_url": "http://127.0.0.1:8080/v1",
+                                    "api_key": ""})
+        assert w == []
+
+    def test_https_loopback_does_not_claim_data_leaves(self):
+        w = engine.remote_warnings({"base_url": "https://localhost:8443/v1",
+                                    "api_key": ""})
+        assert w == []
+
+    def test_invalid_url_reported(self):
+        w = engine.remote_warnings({"base_url": "not-a-url", "api_key": ""})
+        assert any("invalid" in x for x in w)

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -539,7 +539,8 @@ def _doctor_remote(cfg: dict, remote: dict) -> int:
     try:
         names = engine.list_remote_models(remote)
     except Exception as e:
-        print(f"  {YELLOW('warn')}  endpoint   could not list models: {e}")
+        print(f"  {RED('FAIL')}  endpoint   could not reach it: {e}")
+        ok = False
     else:
         if model and model not in names:
             print(f"  {YELLOW('warn')}  endpoint   reachable, but {model} is not among "

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -119,6 +119,14 @@ def cmd_query(args, cfg: dict) -> int:
         print("whatisit: nothing to do -- give me a request in plain English", file=sys.stderr)
         return 2
 
+    # Remote mode sends the request (and host context, if enabled) somewhere
+    # else, which is the one thing this tool otherwise promises never to do.
+    # The warning is opt-in and goes to stderr so -q/$(...) output stays clean.
+    remote = cfg_mod.remote_config(cfg)
+    if remote is not None:
+        for w in engine.remote_warnings(remote):
+            print(DIM(f"  note: {w}"), file=sys.stderr)
+
     try:
         cmds, elapsed, mode = engine.generate(
             prompt, cfg, n=args.num, force_oneshot=args.oneshot, quiet=args.quiet)
@@ -510,8 +518,48 @@ def _fetch_model(args, spec: dict, model_file: Path, slot: Path) -> None:
         print(f"  registered: {slot.name} -> {model_file.name}")
 
 
+def _doctor_remote(cfg: dict, remote: dict) -> int:
+    """doctor output for an OpenAI-compatible backend. Local llama.cpp is unused."""
+    try:
+        base = engine.normalize_endpoint_url(remote["base_url"])
+    except ValueError as e:
+        print(f"  {RED('FAIL')}  remote     {e}")
+        print(f"  info  config     {cfg_mod.config_path()}")
+        print(f"\n{RED('Not ready.')}")
+        return 1
+    model = remote["model"]
+    ok = True
+    print(f"  {GREEN('ok')}    backend    OpenAI-compatible  {base}")
+    if model:
+        print(f"  {GREEN('ok')}    model      {model}")
+    else:
+        print(f"  {RED('FAIL')}  model      not set -- set openai_model or WHATISIT_OPENAI_MODEL")
+        ok = False
+    print(f"  info  auth       {'authenticated' if remote['api_key'] else 'no API key'}")
+    try:
+        names = engine.list_remote_models(remote)
+    except Exception as e:
+        print(f"  {YELLOW('warn')}  endpoint   could not list models: {e}")
+    else:
+        if model and model not in names:
+            print(f"  {YELLOW('warn')}  endpoint   reachable, but {model} is not among "
+                  f"{len(names)} advertised model(s)")
+        else:
+            print(f"  {GREEN('ok')}    endpoint   reachable ({len(names)} model(s))")
+    print(f"  info  config     {cfg_mod.config_path()}")
+    print(f"\n{GREEN('All good.') if ok else RED('Not ready.')}")
+    return 0 if ok else 1
+
+
 def cmd_doctor(args, cfg: dict) -> int:
     print(BOLD("whatisit doctor"))
+
+    # Remote mode means no local model or llama.cpp is required at all; the
+    # local diagnostics below are irrelevant (and would wrongly report failure).
+    remote = cfg_mod.remote_config(cfg)
+    if remote is not None:
+        return _doctor_remote(cfg, remote)
+
     ok = True
 
     model = cfg_mod.find_model()
@@ -584,13 +632,21 @@ def cmd_config(args, cfg: dict) -> int:
                         cfg[k] = v
         print(f"whatisit: wrote {cfg_mod.save_config(cfg)}")
     for k in sorted(cfg):
-        print(f"  {k} = {cfg[k]}")
+        v = cfg[k]
+        # Never print a stored API key; say it is set instead. Secrets belong in
+        # the environment (WHATISIT_OPENAI_API_KEY), but if one is in the
+        # config file it still must not be echoed back.
+        if k == "openai_api_key" and v:
+            v = "********"
+        print(f"  {k} = {v}")
     return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(
-        prog="whatisit", description="Natural language to shell command, fully local. No network.",
+        prog="whatisit",
+        description="Natural language to shell command, local by default. "
+                    "Optionally, any OpenAI-compatible endpoint.",
         epilog="examples:\n"
                "  whatisit find files larger than 100MB in this folder\n"
                "  whatisit -n 3 'find files bigger than 100MB'\n"

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -14,8 +14,67 @@ from pathlib import Path
 # The published filename on Hugging Face, not our identifier.
 MODEL_NAME = "nl2sh-1.5b-Q4_K_M.gguf"
 
+# OpenAI-compatible remote endpoint settings. Env wins over config.json so a
+# secret API key can live only in the environment, never on disk. Each of the
+# three keys is independent: setting only a base URL + model selects a keyless
+# backend (a local LAN llama-server), which is the common case for whatisit.
+# Suffixes for the WHATISIT_* / NL2SH_* env vars, per the env() helper.
+ENDPOINT_ENV = {
+    "openai_base_url": "OPENAI_BASE_URL",
+    "openai_api_key": "OPENAI_API_KEY",
+    "openai_model": "OPENAI_MODEL",
+    "openai_timeout": "OPENAI_TIMEOUT",
+    "openai_max_tokens": "OPENAI_MAX_TOKENS",
+}
+
 APP_NAME = "whatisit"
 LEGACY_NAME = "nl2sh"
+
+
+def remote_config(cfg: dict, timeout_default: float = 120.0) -> dict | None:
+    """Resolve the OpenAI-compatible endpoint, env over config.json.
+
+    Returns None when no base URL is configured (the fully-local default).
+    When a base URL is set it returns a dict with keys:
+      base_url  the configured endpoint (raw; engine normalizes it)
+      api_key   bearer token, or '' if unauthenticated (LAN llama-server)
+      model     the model name to send in the body, or None if not chosen
+      timeout    request timeout in seconds
+      max_tokens generation budget in tokens (512 default: remote endpoints
+                 often run reasoning models that spend tokens 'thinking' before
+                 emitting the command, so the local 64-token budget is too small)
+    An empty openai_base_url (or empty env value) means local mode.
+    """
+    base = env(ENDPOINT_ENV["openai_base_url"]) or cfg.get("openai_base_url")
+    if base is None:
+        return None
+    base = str(base).strip()
+    if not base:
+        return None
+    key = env(ENDPOINT_ENV["openai_api_key"]) or cfg.get("openai_api_key") or ""
+    model = env(ENDPOINT_ENV["openai_model"]) or cfg.get("openai_model") or None
+    if model is not None:
+        model = str(model).strip() or None
+    max_tokens = _openai_int(ENDPOINT_ENV["openai_max_tokens"], cfg, "openai_max_tokens",
+                             512)
+    timeout = _openai_int(ENDPOINT_ENV["openai_timeout"], cfg, "openai_timeout",
+                          timeout_default)
+    return {"base_url": str(base).strip(), "api_key": str(key),
+            "model": str(model) if model else None, "timeout": timeout,
+            "max_tokens": max_tokens}
+
+
+def _openai_int(env_suffix: str, cfg: dict, key: str, default):
+    """Parse an int config value (env over cfg), falling back on garbage."""
+    raw = env(env_suffix)
+    if raw in (None, ""):
+        raw = cfg.get(key)
+    try:
+        return int(raw) if raw not in (None, "") else default
+    except (TypeError, ValueError):
+        return default
+
+
 SYSTEM_PROMPT = (
     "You are a shell command generator. Output exactly one line: a single "
     "POSIX/bash command that accomplishes the user's request. No prose, no "

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -43,16 +43,22 @@ def remote_config(cfg: dict, timeout_default: float = 120.0) -> dict | None:
       max_tokens generation budget in tokens (512 default: remote endpoints
                  often run reasoning models that spend tokens 'thinking' before
                  emitting the command, so the local 64-token budget is too small)
-    An empty openai_base_url (or empty env value) means local mode.
+    An empty openai_base_url (or empty env value) means local mode. An empty
+    env value wins over a stored config value, so `WHATISIT_OPENAI_BASE_URL=`
+    turns remote mode off without editing config.json.
     """
-    base = env(ENDPOINT_ENV["openai_base_url"]) or cfg.get("openai_base_url")
+    raw = env(ENDPOINT_ENV["openai_base_url"])
+    base = cfg.get("openai_base_url") if raw is None else raw
     if base is None:
         return None
     base = str(base).strip()
     if not base:
         return None
-    key = env(ENDPOINT_ENV["openai_api_key"]) or cfg.get("openai_api_key") or ""
-    model = env(ENDPOINT_ENV["openai_model"]) or cfg.get("openai_model") or None
+    raw_key = env(ENDPOINT_ENV["openai_api_key"])
+    key = cfg.get("openai_api_key") if raw_key is None else raw_key
+    key = "" if key is None else str(key)
+    raw_model = env(ENDPOINT_ENV["openai_model"])
+    model = cfg.get("openai_model") if raw_model is None else raw_model
     if model is not None:
         model = str(model).strip() or None
     max_tokens = _openai_int(ENDPOINT_ENV["openai_max_tokens"], cfg, "openai_max_tokens",

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -73,7 +73,7 @@ def remote_config(cfg: dict, timeout_default: float = 120.0) -> dict | None:
 def _openai_int(env_suffix: str, cfg: dict, key: str, default):
     """Parse an int config value (env over cfg), falling back on garbage."""
     raw = env(env_suffix)
-    if raw in (None, ""):
+    if raw is None:
         raw = cfg.get(key)
     try:
         return int(raw) if raw not in (None, "") else default

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -559,7 +559,7 @@ def _query_remote(remote: dict, prompt: str, cfg: dict, n: int,
                                   timeout=remote.get("timeout", 120.0))
     out = post({**base, "temperature": greedy_temp, "n": 1})
     if n <= 1:
-        return out
+        return out[:1]
     sample_temp = max(0.6, greedy_temp)
     for _ in range(n - 1):
         if len(out) >= n:
@@ -569,7 +569,7 @@ def _query_remote(remote: dict, prompt: str, cfg: dict, n: int,
                          "n": 1, "top_p": 0.95})
         except Exception:
             pass  # alternatives are a bonus; never lose the greedy answer over them
-    return out
+    return out[:n]
 
 
 def _query_oneshot(model: Path, cli_bin: Path, prompt: str, cfg: dict, threads: int,

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -1,10 +1,16 @@
-"""Model execution, in two modes.
+"""Model execution, in three modes.
 
-server mode (preferred)
+remote mode (opt-in)
+    An OpenAI-compatible endpoint (any provider, a LAN llama-server, or Ollama)
+    answers. Configured via openai_base_url / openai_model; needs no local
+    model file. The request text leaves the machine, so it is only active when
+    explicitly configured and the CLI warns about it.
+
+server mode (preferred, local)
     A `llama-server` process holds the model in RAM and answers over localhost
     HTTP. Started lazily on first query and left running.
 
-oneshot mode (fallback)
+oneshot mode (fallback, local)
     One `llama-cli` invocation per query.
 
 Why the server exists at all: measured in the target udocker environment, a
@@ -24,6 +30,8 @@ import socket
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -316,41 +324,251 @@ def _post(port: int, body: dict) -> list[str]:
     return [(c["message"]["content"], c.get("finish_reason")) for c in data.get("choices", [])]
 
 
-def _query_server(port: int, prompt: str, cfg: dict, n: int,
-                  system: str | None = None) -> list[str]:
-    """Greedy answer first, then sampled alternatives.
+def _std_body(system: str, user_msg: str, cfg: dict) -> dict:
+    """The pieces any chat-completions body must have.
 
-    Getting this wrong was visible in real use: asking for 3 candidates used to
-    set temperature=0.6 for ALL of them, so the greedy answer -- the one plain
-    `whatisit` returns -- was absent from its own candidate list, and slot 1 was
-    just a dice roll. Observed: "count lines in all python files" offered
-    `grep -R -l '^$' *.py | wc -l` (counts FILES CONTAINING BLANK LINES) as #1
-    while correct answers sat at #2 and #3. Since callers treat #1 as the pick,
-    slot 1 must always be the model's best single guess.
+    Llama-server on our localhost and a remote OpenAI-compatible endpoint
+    accept the same core fields; the caller adds the transport/model-specific
+    ones (model name, repeat penalties, temperature).
     """
-    base = {
-        "messages": [{"role": "system", "content": system or cfg_mod.SYSTEM_PROMPT},
-                     {"role": "user", "content": prompt}],
+    return {
+        "messages": [{"role": "system", "content": system},
+                     {"role": "user", "content": user_msg}],
         "max_tokens": cfg.get("max_tokens", 64),
         "stop": STOP,
-        # Greedy decoding on this model reliably degenerates into flag spam on
-        # some requests -- `zip up this project` produced
-        # `zip -r -9 -q -n -j -0 -9 -n -j -0 ...` on 2 of 2 attempts, which is
-        # reproducible rather than unlucky. A small penalty breaks the loop
-        # without meaningfully changing well-behaved outputs.
-        "repeat_penalty": cfg.get("repeat_penalty", 1.08),
-        "repeat_last_n": 64,
     }
-    out = _post(port, {**base, "temperature": cfg.get("temperature", 0.0)})
+
+
+def _greedy_then_sample(base: dict, n: int, temperature: float,
+                        post) -> list:
+    """Greedy answer first, then sampled alternatives. post(body)->list.
+
+    This is the heart of `-n N`: slot 1 is always the greedy answer (callers
+    treat it as the pick), then `n-1` sampled, distinct-ish alternatives. A
+    failure during sampling must never cost the greedy answer we already have.
+    """
+    out = post({**base, "temperature": temperature})
     if n <= 1:
         return out
-    # Sampling is required for *distinct* alternatives; greedy repeats itself.
     try:
-        out += _post(port, {**base, "n": n - 1,
-                            "temperature": max(0.6, float(cfg.get("temperature") or 0)),
-                            "top_p": 0.95})
+        out += post({**base, "n": n - 1,
+                     "temperature": max(0.6, float(temperature)),
+                     "top_p": 0.95})
     except Exception:
         pass  # alternatives are a bonus; never lose the greedy answer over them
+    return out
+
+
+def _parse_choices(payload: object) -> list[tuple[str, object]]:
+    """Turn a chat-completions response into [(content, finish_reason)].
+
+    The content is untrusted model output (handled downstream by extract), but
+    the *shape* must still be validated: a proxy returning HTML or a partial
+    error instead of JSON should be an explicit failure, not a silent TypeError
+    deep in generate(). Non-string content (some reasoning models emit a dict)
+    is skipped rather than crashing on it.
+    """
+    if not isinstance(payload, dict) or not isinstance(payload.get("choices"), list):
+        raise RuntimeError("endpoint response had no choices")
+    out = []
+    for c in payload["choices"]:
+        if not isinstance(c, dict):
+            continue
+        msg = c.get("message")
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, str):
+            continue
+        out.append((content, c.get("finish_reason")))
+    if not out:
+        raise RuntimeError("endpoint response contained no usable choices")
+    return out
+
+
+class _NoCrossOriginRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow a redirect that changes scheme or host.
+
+    A bearer token is attached to the request; following a redirect elsewhere
+    (scheme or authority) would send that token to a host that never asked for
+    it. Returning None from redirect_request makes urllib surface the redirect
+    as an HTTPError, which we turn into a normal error message."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        old = urllib.parse.urlsplit(req.full_url)
+        new = urllib.parse.urlsplit(newurl)
+        if (old.scheme, old.hostname, old.port) != (new.scheme, new.hostname, new.port):
+            return None
+        try:
+            return super().redirect_request(req, fp, code, msg, headers, newurl)
+        except http.client.HTTPException:
+            return None
+
+
+def normalize_endpoint_url(base: str) -> str:
+    """Canonicalize a base URL: no trailing slash, no fragments/creds, http(s).
+
+    Accepts either `http://host:port/v1` or the full route
+    `http://host:port/v1/chat/completions`; either is reduced to the base to
+    which the engine appends `/chat/completions`. Raises ValueError on input a
+    remote request must never be built from.
+    """
+    base = (base or "").strip()
+    if not base:
+        raise ValueError("endpoint URL is empty")
+    if base.startswith(("http://", "https://")) is False:
+        raise ValueError("endpoint URL must start with http:// or https://")
+    p = urllib.parse.urlsplit(base)
+    if not p.hostname:
+        raise ValueError("endpoint URL has no host")
+    if p.username or p.password:
+        raise ValueError("endpoint URL must not embed credentials")
+    if p.fragment:
+        raise ValueError("endpoint URL must not contain a fragment")
+    path = p.path.rstrip("/")
+    # Pasted the full route? Drop it so we append once below.
+    if path.endswith("/chat/completions"):
+        path = path[: -len("/chat/completions")]
+    return urllib.parse.urlunsplit((p.scheme, p.netloc, path, "", ""))
+
+
+def _is_loopback(hostname: str | None) -> bool:
+    return (hostname or "").lower() in ("127.0.0.1", "::1", "localhost")
+
+
+def remote_warnings(remote: dict) -> list[str]:
+    """Human-facing safety notes for a configured remote endpoint.
+
+    Remote mode deliberately breaks the tool's core promise that nothing leaves
+    the machine, so the caller should surface these before the first request.
+    """
+    try:
+        url = normalize_endpoint_url(remote["base_url"])
+    except ValueError as e:
+        return [f"invalid remote endpoint: {e}"]
+    sp = urllib.parse.urlsplit(url)
+    loopback = _is_loopback(sp.hostname)
+    warns = []
+    if not loopback:
+        warns.append("remote endpoint: your request text leaves this machine")
+    if sp.scheme == "http" and not loopback:
+        if remote.get("api_key"):
+            warns.append("endpoint is plain HTTP; the API key and request travel unencrypted")
+        else:
+            warns.append("endpoint is plain HTTP; the request travels unencrypted")
+    return warns
+
+
+def _remote_post(base: str, model: str, api_key: str, body: dict,
+                 timeout: float = 120.0) -> list[tuple[str, object]]:
+    """POST a chat-completion to a remote OpenAI-compatible endpoint.
+
+    Bearer auth only when a key is given (a LAN llama-server needs none). The
+    response is buffered under the same _MAX_RESPONSE_BYTES cap as the local
+    server, and errors never include the API key.
+    """
+    url = normalize_endpoint_url(base) + "/chat/completions"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(url, data=json.dumps(body).encode(),
+                                 headers=headers, method="POST")
+    opener = urllib.request.build_opener(_NoCrossOriginRedirect)
+    try:
+        with opener.open(req, timeout=timeout) as r:
+            payload = _read_capped(r)
+    except urllib.error.HTTPError as e:
+        detail = _read_capped(e).decode("utf-8", "replace").strip()
+        # Error bodies are untrusted and may echo our request; keep it tiny.
+        if len(detail) > 200:
+            detail = detail[:200] + "..."
+        raise RuntimeError(f"endpoint returned HTTP {e.code}: {detail or e.reason}") from None
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"endpoint unreachable: {e.reason}") from None
+    try:
+        return _parse_choices(json.loads(payload))
+    except json.JSONDecodeError:
+        raise RuntimeError("endpoint returned non-JSON response") from None
+
+
+def list_remote_models(remote: dict, timeout: float = 5.0) -> list[str]:
+    """GET {base}/models. Used by doctor only; generation never guesses a model."""
+    url = normalize_endpoint_url(remote["base_url"]) + "/models"
+    headers = {}
+    if remote.get("api_key"):
+        headers["Authorization"] = f"Bearer {remote['api_key']}"
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    opener = urllib.request.build_opener(_NoCrossOriginRedirect)
+    try:
+        with opener.open(req, timeout=timeout) as r:
+            payload = _read_capped(r)
+    except urllib.error.HTTPError as e:
+        detail = _read_capped(e).decode("utf-8", "replace").strip()
+        if len(detail) > 200:
+            detail = detail[:200] + "..."
+        raise RuntimeError(f"endpoint returned HTTP {e.code}: {detail or e.reason}") from None
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"endpoint unreachable: {e.reason}") from None
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        raise RuntimeError("endpoint /models returned non-JSON") from None
+    items = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        raise RuntimeError("endpoint /models had no data list")
+    out = []
+    for item in items:
+        if isinstance(item, dict) and isinstance(item.get("id"), str):
+            out.append(item["id"])
+    return out
+
+
+def _query_server(port: int, prompt: str, cfg: dict, n: int,
+                  system: str | None = None) -> list[str]:
+    """Greedy answer first, then sampled alternatives (see _greedy_then_sample).
+
+    The llama-specific penalties stay on the server body only -- they are what
+    the local model needs to avoid flag-spam loops, and remote endpoints do not
+    all accept them.
+    """
+    base = _std_body(system or cfg_mod.SYSTEM_PROMPT, prompt, cfg)
+    base["repeat_penalty"] = cfg.get("repeat_penalty", 1.08)
+    base["repeat_last_n"] = 64
+    return _greedy_then_sample(base, n, float(cfg.get("temperature", 0.0)),
+                               lambda b: _post(port, b))
+
+
+def _query_remote(remote: dict, prompt: str, cfg: dict, n: int,
+                  system: str | None = None) -> list[tuple[str, object]]:
+    """Query an OpenAI-compatible endpoint, greedy answer then alternatives.
+
+    Only broadly-supported fields go on the wire: model, messages, max_tokens,
+    stop, temperature, n, top_p. Llama-specific knobs (repeat penalties) are
+    local-only.
+
+    Alternatives are one temperature-sampled call each with n=1 rather than a
+    single call with n=N-1: llama-server commonly runs `--parallel 1`, which
+    rejects n > 1 outright (HTTP 400), and per-call sampling still yields
+    distinct candidates. A failed alternative is non-fatal -- the greedy answer
+    we already have is never lost.
+    """
+    base = _std_body(system or cfg_mod.SYSTEM_PROMPT, prompt, cfg)
+    base["model"] = remote["model"]
+    base["max_tokens"] = remote.get("max_tokens", base.get("max_tokens", 512))
+    greedy_temp = float(cfg.get("temperature", 0.0))
+    post = lambda b: _remote_post(remote["base_url"], remote["model"],
+                                  remote["api_key"], b,
+                                  timeout=remote.get("timeout", 120.0))
+    out = post({**base, "temperature": greedy_temp, "n": 1})
+    if n <= 1:
+        return out
+    sample_temp = max(0.6, greedy_temp)
+    for _ in range(n - 1):
+        if len(out) >= n:
+            break
+        try:
+            out += post({**base, "temperature": sample_temp,
+                         "n": 1, "top_p": 0.95})
+        except Exception:
+            pass  # alternatives are a bonus; never lose the greedy answer over them
     return out
 
 
@@ -407,9 +625,46 @@ def looks_degenerate(cmd: str, min_repeats: int = 4) -> bool:
     return bool(counts) and counts.most_common(1)[0][1] >= min_repeats
 
 
+def _collect_commands(raws) -> list[str]:
+    """Extract, drop bad/finished/duplicate candidates (shared by all modes)."""
+    cmds, seen = [], set()
+    for raw, finish in raws:
+        c = extract(raw)
+        if not c or c in seen:
+            continue
+        # A generation that stopped because it ran out of budget is not a
+        # finished command, and must not be presented as one. The observed case
+        # was `zip -r -9 -q -m -j -0 -1 -1 ...`: truncated mid-flag-spam, yet it
+        # still carried `-m`, which DELETES the source files. Showing that as an
+        # answer is worse than showing nothing.
+        if finish == "length" or looks_degenerate(c):
+            continue
+        seen.add(c)
+        cmds.append(c)
+    return cmds
+
+
 def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
              quiet: bool = False) -> tuple[list[str], float, str]:
-    """Return (commands, elapsed_seconds, mode). Commands are already extracted."""
+    """Return (commands, elapsed_seconds, mode). Commands are already extracted.
+
+    mode is one of "remote", "server", or "oneshot". Remote mode is selected by
+    a configured OpenAI-compatible base URL and needs no local model at all.
+    """
+    remote = cfg_mod.remote_config(cfg)
+    if remote is not None:
+        if not remote["model"]:
+            raise RuntimeError(
+                "remote endpoint configured but no model selected -- "
+                "set openai_model or WHATISIT_OPENAI_MODEL")
+        if force_oneshot:
+            raise RuntimeError(
+                "--oneshot applies to the local backend and cannot be used with a remote endpoint")
+        system, user_msg = hostctx.build(prompt, enabled=cfg.get("host_context", True))
+        t0 = time.time()
+        raws = _query_remote(remote, user_msg, cfg, n, system=system)
+        return _collect_commands(raws), time.time() - t0, "remote"
+
     model = cfg_mod.find_model()
     if model is None:
         raise FileNotFoundError("no model found -- run `whatisit setup`")
@@ -443,18 +698,5 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
         raws = _query_oneshot(model, cli, user_msg, cfg, threads, system=system)
         mode = "oneshot"
 
-    cmds, seen = [], set()
-    for raw, finish in raws:
-        c = extract(raw)
-        if not c or c in seen:
-            continue
-        # A generation that stopped because it ran out of budget is not a
-        # finished command, and must not be presented as one. The observed case
-        # was `zip -r -9 -q -m -j -0 -1 -1 ...`: truncated mid-flag-spam, yet it
-        # still carried `-m`, which DELETES the source files. Showing that as an
-        # answer is worse than showing nothing.
-        if finish == "length" or looks_degenerate(c):
-            continue
-        seen.add(c)
-        cmds.append(c)
+    cmds = _collect_commands(raws)
     return cmds, time.time() - t0, mode


### PR DESCRIPTION
Fixes #22 

Added support for an OpenAI-compatible endpoint. I tested this with my local llama.cpp instance with both Qwen3.6-35B-A3B and DeepSeek-V4-Flash. DeepSeek, as expected, takes more time (hence the extra timeout). Qwen3.6-35B-A3B is much faster than DeepSeek-V4-Flash (0.4s vs ~4–8s).  I also used a default of 512 tokens for `openai_max_tokens`  to account for the thinking tokens. In general, non-thinking models work well and are reasonably fast. 

## How was it tested?

- [x] `pytest -q` passes locally (`whatisit_pkg/`)
- [x] `ruff check .` is clean (or new findings are explained below)
- [x] If this touches `safety.py` or `extract.py`: no case was removed or
      weakened in `tests/test_safety.py` / `tests/test_extract.py` -- only
      added to
