### PR TITLE
Build the nix flake in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,25 @@ jobs:
           python -c "import whatisit, whatisit.cli, whatisit.engine, whatisit.safety"
           python -m whatisit --help > /dev/null
 
+  nix:
+    name: nix (flake builds)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v27
+
+      # buildPythonApplication runs pytest inside the build, so this covers
+      # both "the flake evaluates" and "the package works".
+      - name: Build the flake
+        run: nix build .#whatisit
+
+      - name: Run the built binary
+        run: ./result/bin/whatisit --help
+
   package:
     name: package (build, metadata, wheel + sdist install)
     runs-on: ubuntu-latest


### PR DESCRIPTION
The flake landed in #17 and nothing checks it. This builds it on every PR and runs the resulting binary.

Linux only. macOS failed installing nix on the runner rather than on the flake itself, so it is left out for now rather than carried as a known-failing job.