### PR TITLE
Create the GitHub Release on the push path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -221,6 +221,27 @@ jobs:
           echo "::error::Failed to create or push tag $TAG"
           exit 1
 
+      # The tag alone is not a Release, so the push path used to publish to
+      # PyPI and leave the Releases page a version behind.
+      - name: Ensure GitHub Release exists
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; nothing to do"
+            exit 0
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            whatisit_pkg/dist/*
+
       - name: Verify PyPI release
         env:
           VERSION: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
0.2.2 published to PyPI and tagged, but the Releases page stayed on 0.2.1. The push path only creates a tag; a Release is a separate object and the workflow only touched one on the release trigger.

Adds a step that creates the Release with generated notes and attaches the wheel and sdist. Idempotent, skips if the release already exists.