### PR TITLE
docs: code of conduct, security policy, issue template checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,17 @@ name: Bug report
 description: Something in whatisit is broken or behaving unexpectedly
 labels: ["bug"]
 body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before filing
+      options:
+        - label: I read the [README](https://github.com/ThorOdinson246/whatisit-nl2sh#readme)
+          required: true
+        - label: I searched open and closed issues for the same problem
+          required: true
+        - label: I ran `whatisit doctor` and included the output below
+          required: true
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,15 @@ name: Feature request
 description: Suggest an improvement or a new capability for whatisit
 labels: ["enhancement"]
 body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before filing
+      options:
+        - label: I read the [README](https://github.com/ThorOdinson246/whatisit-nl2sh#readme)
+          required: true
+        - label: I searched open and closed issues for the same request
+          required: true
   - type: textarea
     id: problem
     attributes:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer at CONTACT_EMAIL_PLACEHOLDER.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the maintainer at CONTACT_EMAIL_PLACEHOLDER.
+reported privately through GitHub, at
+https://github.com/ThorOdinson246/whatisit-nl2sh/security/advisories/new.
+That form is labelled for security reports, but it is the private channel to
+the maintainer and conduct reports are welcome there too.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release on PyPI gets fixes. Please upgrade before reporting.
+
+## Reporting a vulnerability
+
+Use [private vulnerability reporting](https://github.com/ThorOdinson246/whatisit-nl2sh/security/advisories/new).
+Please do not open a public issue for a security problem.
+
+Include what you ran, what happened, and the output of `whatisit doctor`.
+I will acknowledge within a week.
+
+## What counts as a vulnerability
+
+This tool turns natural language into shell commands using a local model. Some
+things that look alarming are working as designed, and some are not.
+
+In scope:
+
+- A way to make `whatisit` run a command without the confirmation prompt
+- A way for another user on the same machine to read your prompts, reach the
+  model server, or make it answer in place of the real one
+- Config, token, or log files written with permissions that let others read them
+- A path that sends your prompts somewhere you did not configure
+- Command injection through a file path, environment variable, or config value
+
+Out of scope:
+
+- The model generating a wrong or destructive command. It is a 1.5B model. The
+  safety check is a seatbelt, not a sandbox, and nothing runs without you
+  confirming it.
+- The safety check missing a dangerous command. Report these as normal issues,
+  they are useful, but they are not vulnerabilities.
+- Anything that requires you to already have root, or to have deliberately
+  pointed the tool at a hostile binary or endpoint.
+
+## Things worth knowing
+
+- **Do not run `whatisit` through `sudo`.** It executes binaries whose paths come
+  from environment variables you control. Across a privilege boundary, that is a
+  way to run anything as root.
+- The model server listens on a UNIX socket inside a `0700` directory with a
+  per-run bearer token, so other users on the machine cannot reach it. Setting
+  `WHATISIT_FORCE_TCP=1` gives that up in exchange for working on systems where
+  the socket path fails to bind.
+- If you configure an OpenAI-compatible endpoint, your prompts go to that
+  endpoint. That is the point of the feature, but it is worth saying out loud.
+- `host_context` is off by default. With it on, the prompt includes your current
+  directory and its file listing, which then goes wherever the prompt goes.


### PR DESCRIPTION
Adds the two community files GitHub looks for, and a checkbox on the issue templates.

- `CODE_OF_CONDUCT.md`: Contributor Covenant 2.1, unmodified.
- `SECURITY.md`: reporting goes through GitHub private vulnerability reporting, which I enabled on the repo. Says what counts as a vulnerability and what does not, since "the model wrote a bad command" is going to get reported otherwise.
- Issue templates now require confirming the README was read and issues were searched. Bug reports also require `whatisit doctor` output.

