### PR TITLE
feat(cli): per-invocation flags and confirm-default fix

### DIFF
--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -11,6 +11,8 @@ These cover cases that were REAL bugs found by typing realistic requests:
 None of this starts a server or touches the network: engine.generate is
 monkeypatched wherever cmd_query would otherwise call into it.
 """
+import os
+
 import pytest
 
 from whatisit import cli
@@ -293,3 +295,152 @@ class TestRemoteCli:
         assert rc == 0
         assert captured.out.strip() == "ls"
         assert "leaves this machine" in captured.err
+
+
+# --------------------------------------------------------------- QueryArgs extras
+
+def test_port_threads_model_flags_parse():
+    a = cli.QueryArgs(["--port", "9000", "--threads", "8", "--model",
+                       "/models/3b.gguf", "list", "files"])
+    assert a.port == 9000
+    assert a.threads == 8
+    assert a.model == "/models/3b.gguf"
+    assert a.words == ["list", "files"]
+
+
+def test_ctx_size_flag_parse():
+    a = cli.QueryArgs(["--ctx-size", "4096", "list", "files"])
+    assert a.ctx_size == 4096
+    assert a.words == ["list", "files"]
+
+
+def test_no_host_context_and_no_grammar_flags():
+    a = cli.QueryArgs(["--no-host-context", "--no-grammar", "list", "files"])
+    assert a.host_context is False
+    assert a.grammar is False
+    assert a.words == ["list", "files"]
+
+
+def test_flag_needs_value_raises():
+    with pytest.raises(ValueError):
+        cli.QueryArgs(["--port"])
+    with pytest.raises(ValueError):
+        cli.QueryArgs(["--threads"])
+    with pytest.raises(ValueError):
+        cli.QueryArgs(["--model"])
+
+
+def test_debug_flag_is_set():
+    a = cli.QueryArgs(["--debug", "list", "files"])
+    assert a.debug is True
+    assert a.words == ["list", "files"]
+
+
+def test_yes_flag_and_enable_overrides_parse():
+    a = cli.QueryArgs(["-y", "--host-context", "--grammar", "list", "files"])
+    assert a.yes is True
+    assert a.host_context is True
+    assert a.grammar is True
+    assert a.words == ["list", "files"]
+
+
+def test_enable_and_disable_host_context_are_mutually_consistent():
+    a = cli.QueryArgs(["--host-context", "list", "files"])
+    assert a.host_context is True
+    b = cli.QueryArgs(["--no-host-context", "list", "files"])
+    assert b.host_context is False
+
+
+def test_port_range_is_validated():
+    with pytest.raises(ValueError, match="1\\.\\.65535"):
+        cli.QueryArgs(["--port", "0", "list", "files"])
+    with pytest.raises(ValueError, match="1\\.\\.65535"):
+        cli.QueryArgs(["--port", "70000", "list", "files"])
+    assert cli.QueryArgs(["--port", "65535", "list", "files"]).port == 65535
+
+
+def test_ctx_size_and_threads_ranges_are_validated():
+    with pytest.raises(ValueError, match="> 0"):
+        cli.QueryArgs(["--ctx-size", "0", "list", "files"])
+    with pytest.raises(ValueError, match="> 0"):
+        cli.QueryArgs(["--ctx-size", "-1", "list", "files"])
+    with pytest.raises(ValueError, match=">= 0"):
+        cli.QueryArgs(["--threads", "-1", "list", "files"])
+
+
+def test_value_taking_query_flags_are_flagged_when_stray():
+    a = cli.QueryArgs(["list", "files", "--port", "9000"])
+    assert a.port is None
+    assert a.stray_flags == ["--port"]
+    b = cli.QueryArgs(["list", "files", "--ctx-size", "4096"])
+    assert b.stray_flags == ["--ctx-size"]
+
+
+# --------------------------------------------------------------- cmd_query wiring
+
+class TestQueryFlagsApply:
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+
+    def test_port_thread_model_overrides_config(self, monkeypatch, tmp_path, capsys):
+        self._isolate(monkeypatch, tmp_path)
+        seen = {}
+        def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                          for_execution=False):
+            seen["cfg"] = dict(cfg)
+            return (["ls -la"], 0.01, "server")
+        monkeypatch.setattr(cli.engine, "generate", fake_generate)
+        rc = cli.main(["--port", "9100", "--threads", "2",
+                       "--model", "/m.gguf", "list", "files"])
+        assert rc == 0
+        assert seen["cfg"]["server_port"] == 9100
+        assert seen["cfg"]["threads"] == 2
+        assert os.environ["WHATISIT_MODEL"] == "/m.gguf"
+
+    def test_no_grammar_disables_grammar(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        seen = {}
+        def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                          for_execution=False):
+            seen["cfg"] = dict(cfg)
+            return (["ls"], 0.01, "server")
+        monkeypatch.setattr(cli.engine, "generate", fake_generate)
+        rc = cli.main(["--no-grammar", "list", "files"])
+        assert rc == 0
+        assert seen["cfg"]["use_grammar"] is False
+
+    def test_debug_emits_prompt_to_stderr(self, monkeypatch, tmp_path, capsys):
+        self._isolate(monkeypatch, tmp_path)
+        # Only assert the debug output, not actual execution.
+        monkeypatch.setattr(cli.engine, "generate",
+                            lambda *a, **k: (["ls"], 0.01, "server"))
+        monkeypatch.setattr(cli.engine.hostctx, "build",
+                            lambda p, enabled=True, cwd=None: ("SYS", p))
+        rc = cli.main(["--debug", "list", "files"])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "--debug" in err
+        assert "list files" in err
+
+    def test_debug_shows_grammar_when_available(self, monkeypatch, tmp_path, capsys):
+        self._isolate(monkeypatch, tmp_path)
+        cli.main(["config", "--set", "host_context=true"])
+        capsys.readouterr()
+        monkeypatch.setattr(cli.engine, "generate",
+                            lambda *a, **k: (["ls"], 0.01, "server"))
+        monkeypatch.setattr(cli.engine.hostctx, "build",
+                            lambda p, enabled=True, cwd=None: ("SYS", p))
+        monkeypatch.setattr(cli.engine.hostctx, "stable_facts",
+                            lambda *a, **k: {"pkg": "pacman"})
+        # grammar_for_pkg may not exist (PR A vs PR B); if so, create a stub
+        # so the debug path can derive a grammar through the hasattr guard.
+        # raising=False restores the original after the test either way.
+        monkeypatch.setattr(cli.engine.hostctx, "grammar_for_pkg",
+                            lambda pkg: "grammar-blob", raising=False)
+        rc = cli.main(["--debug", "list", "files"])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "--debug" in err
+        assert "grammar-blob" in err
+        assert "list files" in err

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -629,6 +629,95 @@ class TestGenerateDiscardsTruncatedCandidates:
             engine.generate("do something", {})
 
 
+class TestServerOverridesReachTheBoundary:
+    """The --port/--threads/--ctx-size overrides must be observable at the
+    engine boundary, not just recorded in the cfg dict handed to generate().
+
+    These sit at the command-construction seam: generate() resolves threads
+    and must forward the fixed port + context size to start_server/_query_oneshot.
+    """
+
+    def _fake_cfg_and_model(self, monkeypatch, tmp_path):
+        model = tmp_path / "model.gguf"
+        model.write_bytes(b"fake")
+        monkeypatch.setattr(cfg_mod, "find_model", lambda: model)
+        monkeypatch.setattr(engine, "hostctx", _FakeHostCtx())
+        srv = tmp_path / "llama-server"
+        srv.write_bytes(b"fake")
+        monkeypatch.setenv("WHATISIT_LLAMA_SERVER", str(srv))
+
+    def test_server_mode_forwards_fixed_port_and_ctx_size(self, monkeypatch, tmp_path):
+        self._fake_cfg_and_model(monkeypatch, tmp_path)
+        seen = {}
+        monkeypatch.setattr(
+            engine, "start_server",
+            lambda model, server_bin, threads, wait=180.0, quiet=False,
+                   port=None, ctx_size=2048: seen.update(
+                       threads=threads, port=port, ctx_size=ctx_size) or 12345)
+        monkeypatch.setattr(engine, "_query_server",
+                            lambda port, prompt, cfg, n, system=None, grammar=None:
+                                [("ls", "stop")])
+        cfg = {"server_port": 9100, "ctx_size": 4096, "threads": 2}
+        cmds, _, mode = engine.generate("list files", cfg)
+        assert mode == "server"
+        assert seen["threads"] == 2
+        assert seen["port"] == 9100
+        assert seen["ctx_size"] == 4096
+
+    def test_oneshot_mode_forwards_ctx_size(self, monkeypatch, tmp_path):
+        self._fake_cfg_and_model(monkeypatch, tmp_path)
+        seen = {}
+        monkeypatch.setattr(engine, "start_server",
+                            lambda *a, **k: (_ for _ in ()).throw(AssertionError("no server")))
+        monkeypatch.setattr(cfg_mod, "find_llama_cli", lambda: tmp_path / "llama-cli")
+        monkeypatch.setattr(engine, "_query_oneshot",
+                            lambda model, cli_bin, prompt, cfg, threads,
+                                   system=None, grammar=None, ctx_size=2048: seen.update(
+                                       threads=threads, ctx_size=ctx_size) or [("ls", "stop")])
+        cfg = {"threads": 1, "ctx_size": 512}
+        cmds, _, mode = engine.generate("list files", cfg, force_oneshot=True)
+        assert mode == "oneshot"
+        assert seen["threads"] == 1
+        assert seen["ctx_size"] == 512
+
+    def test_start_server_builds_command_with_fixed_port_and_ctx_size(self, monkeypatch, tmp_path):
+        # Command-construction boundary: the fixed port and ctx size must
+        # actually reach the llama-server argv, not just the function args.
+        model = tmp_path / "model.gguf"
+        server_bin = tmp_path / "llama-server"
+        model.write_bytes(b"x")
+        server_bin.write_bytes(b"x")
+        state_dir = tmp_path / "run"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(cfg_mod, "env", lambda suffix, default=None: None)
+        monkeypatch.setattr(cfg_mod, "load_config", lambda: {})
+        monkeypatch.setattr(engine, "running_port", lambda: None)
+        monkeypatch.setattr(engine, "_state_dir", lambda: state_dir)
+        monkeypatch.setattr(engine, "_write_private", lambda *a, **k: None)
+        monkeypatch.setattr(engine, "_alive",
+                            lambda port=None, timeout=0.6, expected_pid=None: True)
+        captured = {}
+        class _FakeProc:
+            pid = 2468
+
+            def poll(self):
+                return None
+        def fake_popen(cmd, *a, **k):
+            captured["cmd"] = cmd
+            return _FakeProc()
+        monkeypatch.setattr(engine.subprocess, "Popen", fake_popen)
+        port = engine.start_server(model, server_bin, 2, wait=0.05, quiet=True,
+                                   port=9100, ctx_size=4096)
+        assert port == 9100
+        cmd = captured["cmd"]
+        assert "--port" in cmd
+        assert cmd[cmd.index("--port") + 1] == "9100"
+        assert "-c" in cmd
+        assert cmd[cmd.index("-c") + 1] == "4096"
+        assert "-t" in cmd
+        assert cmd[cmd.index("-t") + 1] == "2"
+
+
 class _FakeHostCtx:
     @staticmethod
     def build(prompt, enabled=True, cwd=None, include_volatile=True):

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -113,6 +113,16 @@ def _warn_stray_flags(args) -> None:
     print(DIM(f"        flags go first:  whatisit {first} {rest}"), file=sys.stderr)
 
 
+def _emit_debug(prompt: str, system: str, user_msg: str, grammar: str | None) -> None:
+    """Print the exact prompt + grammar the model sees, for diagnosing failures."""
+    print(DIM(f"  --debug: system prompt length = {len(system)}"), file=sys.stderr)
+    print(DIM(f"  --debug: grammar = {'none' if grammar is None else 'set'}"), file=sys.stderr)
+    print(DIM(f"  --debug: user prompt:\n{user_msg}"), file=sys.stderr)
+    if grammar:
+        print(DIM(f"  --debug: GBNF grammar:\n{grammar}"), file=sys.stderr)
+    print(DIM(f"  --debug: request:\n{prompt}"), file=sys.stderr)
+
+
 def cmd_query(args, cfg: dict) -> int:
     prompt = " ".join(args.words).strip()
     if not prompt:
@@ -121,10 +131,34 @@ def cmd_query(args, cfg: dict) -> int:
 
     # Per-invocation overrides from CLI flags. These win over the saved config
     # file but do not persist to it (that is `whatisit config --set`'s job).
+    if args.model is not None:
+        os.environ["WHATISIT_MODEL"] = args.model
+    if args.threads is not None:
+        cfg["threads"] = args.threads
+    if args.port is not None:
+        cfg["server_port"] = args.port
+    if args.ctx_size is not None:
+        cfg["ctx_size"] = args.ctx_size
     if args.host_context is not None:
         cfg["host_context"] = args.host_context
     if args.grammar is not None:
         cfg["use_grammar"] = args.grammar
+    if args.debug:
+        # Show the exact prompt sent to the model and the active GBNF grammar
+        # (if any). Intended for diagnosing why the 1.5B model misbehaves; goes
+        # to stderr so `-q` output is unaffected.
+        system, user_msg = engine.hostctx.build(prompt,
+                                                enabled=cfg.get("host_context", True))
+        pkg = "unknown"
+        grammar = None
+        if cfg.get("host_context", True) and cfg.get("use_grammar", True):
+            try:
+                pkg = engine.hostctx.stable_facts().get("pkg", "unknown")
+            except OSError:
+                pass
+            if pkg != "unknown" and hasattr(engine.hostctx, "grammar_for_pkg"):
+                grammar = engine.hostctx.grammar_for_pkg(pkg)
+        _emit_debug(prompt, system, user_msg, grammar)
 
     # Remote mode sends the request (and host context, if enabled) somewhere
     # else, which is the one thing this tool otherwise promises never to do.
@@ -232,12 +266,17 @@ def cmd_query(args, cfg: dict) -> int:
             print("whatisit: refusing to execute without an interactive confirmation.",
                   file=sys.stderr)
             return 6
+        # Default stays explicit: "y"/"yes" is required. -y/--yes or
+        # confirm_default=true opts into treating an empty answer as yes.
+        empty_is_yes = args.yes or cfg.get("confirm_default", False)
+        accept = ("", "y", "yes") if empty_is_yes else ("y", "yes")
+        prompt = "[Y/n]" if empty_is_yes else "[y/N]"
         try:
-            ans = input(f"\n{BOLD('Run this?')} [y/N] ").strip().lower()
+            ans = input(f"\n{BOLD('Run this?')} {prompt} ").strip().lower()
         except (EOFError, KeyboardInterrupt):
             print()
             return 130
-        if ans not in ("y", "yes"):
+        if ans not in accept:
             print("whatisit: not running.", file=sys.stderr)
             return 0
 
@@ -672,6 +711,16 @@ def build_parser() -> argparse.ArgumentParser:
     ap.add_argument("-t", "--timing", action="store_true", help="report latency")
     ap.add_argument("--oneshot", action="store_true",
                     help="bypass the resident server (slower; for debugging)")
+    ap.add_argument("-y", "--yes", action="store_true",
+                    help="with -e, treat an empty confirm answer as yes ([Y/n])")
+    ap.add_argument("--port", type=int, metavar="PORT",
+                    help="fixed TCP port for the resident server (1-65535)")
+    ap.add_argument("--threads", type=int, metavar="N",
+                    help="override saved thread count for this invocation")
+    ap.add_argument("--ctx-size", type=int, metavar="N",
+                    help="override the saved context size for this invocation")
+    ap.add_argument("--model", metavar="PATH",
+                    help="override the registered model for this invocation")
     ap.add_argument("--host-context", dest="host_context", action="store_true",
                     help="enable host context for this invocation")
     ap.add_argument("--no-host-context", dest="host_context", action="store_false",
@@ -680,6 +729,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="enable the GBNF grammar for this invocation")
     ap.add_argument("--no-grammar", dest="grammar", action="store_false",
                     help="disable the GBNF grammar for this invocation")
+    ap.add_argument("--debug", action="store_true",
+                    help="print the exact prompt and grammar sent to the model")
 
     sub = ap.add_subparsers(dest="sub")
     s = sub.add_parser("setup", help="first-run setup: fetch the runtime and model")
@@ -711,8 +762,9 @@ def build_parser() -> argparse.ArgumentParser:
 SUBCOMMANDS = {"setup", "doctor", "stop", "config"}
 _FLAGS_NOARG = {"-e", "--execute", "-q", "--quiet", "-t", "--timing", "--oneshot",
                 "--host-context", "--no-host-context",
-                "--grammar", "--no-grammar"}
+                "--grammar", "--no-grammar", "--debug", "-y", "--yes"}
 _FLAGS_ARG = {"-n", "--num"}
+_FLAGS_QUERY_ARG = {"--port", "--threads", "--ctx-size", "--model"}
 
 
 class QueryArgs:
@@ -732,7 +784,8 @@ class QueryArgs:
     def __init__(self, argv: list[str]):
         self.num, self.execute, self.quiet = 1, False, False
         self.timing, self.oneshot = False, False
-        self.host_context, self.grammar = None, None
+        self.port, self.threads, self.ctx_size, self.model = None, None, None, None
+        self.host_context, self.grammar, self.debug, self.yes = None, None, False, False
         i = 0
         while i < len(argv):
             a = argv[i]
@@ -748,15 +801,37 @@ class QueryArgs:
                     self.grammar = True
                 elif a == "--no-grammar":
                     self.grammar = False
+                elif a in ("-y", "--yes"):
+                    self.yes = True
                 else:
                     setattr(self, {"-e": "execute", "--execute": "execute",
                                    "-q": "quiet", "--quiet": "quiet",
                                    "-t": "timing", "--timing": "timing",
-                                   "--oneshot": "oneshot"}[a], True)
+                                   "--oneshot": "oneshot",
+                                   "--debug": "debug"}[a], True)
             elif a in _FLAGS_ARG:
                 if i + 1 >= len(argv):
                     raise ValueError(f"{a} needs a number")
                 self.num = int(argv[i + 1])
+                i += 1
+            elif a in _FLAGS_QUERY_ARG:
+                if i + 1 >= len(argv):
+                    raise ValueError(f"{a} needs a value")
+                val = argv[i + 1]
+                if a == "--port":
+                    self.port = int(val)
+                    if not 1 <= self.port <= 65535:
+                        raise ValueError(f"--port must be 1..65535, got {self.port}")
+                elif a == "--threads":
+                    self.threads = int(val)
+                    if self.threads < 0:
+                        raise ValueError(f"--threads must be >= 0, got {self.threads}")
+                elif a == "--ctx-size":
+                    self.ctx_size = int(val)
+                    if self.ctx_size <= 0:
+                        raise ValueError(f"--ctx-size must be > 0, got {self.ctx_size}")
+                else:
+                    self.model = val
                 i += 1
             elif a.startswith("-n") and len(a) > 2 and a[2:].isdigit():
                 self.num = int(a[2:])          # -n3
@@ -778,7 +853,7 @@ class QueryArgs:
         # answers something odd. Record it so the caller can say so rather
         # than leaving the user to work it out. A `--` means the user already
         # said they meant it literally, so stay quiet in that case.
-        known = _FLAGS_NOARG | _FLAGS_ARG
+        known = _FLAGS_NOARG | _FLAGS_ARG | _FLAGS_QUERY_ARG
         self.stray_flags = [] if explicit else [w for w in self.words if w in known]
 
 

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -92,6 +92,10 @@ DEFAULTS = {
     "max_tokens": 64,
     "temperature": 0.0,    # greedy: same question -> same command
     "confirm_execute": True,
+    # OFF by default: -e output goes straight to a shell, so Enter must not run
+    # commands unless the user opted in. Set confirm_default=true to get [Y/n]
+    # (empty answer means yes) on the confirmation prompt.
+    "confirm_default": False,
     # OFF by default. It is cheap (prefix-cached) but MEASURED HARMFUL on the
     # only benchmark available: 54.2% -> 45.1% pass, p=0.0004. See hostctx.py.
     "host_context": False,
@@ -101,8 +105,11 @@ DEFAULTS = {
     # postprocessing remains active as a backstop.
     "use_grammar": True,
     # Serve over a TCP port instead of a UNIX socket. Set by `setup` when it
-    # installs a runtime whose llama-server cannot bind a socket path.
+    # installs a runtime whose llama-server cannot bind a socket path. A fixed
+    # value forces that port; None keeps the current auto/free-port behaviour.
     "force_tcp": False,
+    "server_port": None,       # fixed TCP port for the resident server
+    "ctx_size": 2048,          # context size passed to llama-server/llama-cli
 }
 
 

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -207,6 +207,10 @@ def _port_file() -> Path:
     return _state_dir() / "server.port"
 
 
+def _params_file() -> Path:
+    return _state_dir() / "server.params"
+
+
 def _free_port() -> int:
     with socket.socket() as s:
         s.bind((HOST, 0))
@@ -468,16 +472,24 @@ def stop_server() -> bool:
     _port_file().unlink(missing_ok=True)
     _sock_path().unlink(missing_ok=True)
     _token_path().unlink(missing_ok=True)
+    _params_file().unlink(missing_ok=True)
     return stopped
 
 
-def start_server(model: Path, server_bin: Path, threads: int,
-                 wait: float = 180.0, quiet: bool = False) -> int:
-    if _sock_path().exists() and _alive():
-        return 0
-    if (existing := running_port()) is not None:
-        return existing
+def _read_params() -> dict | None:
+    """The launch parameters of the resident server, if any are recorded."""
+    pf = _params_file()
+    if not pf.exists():
+        return None
+    try:
+        return json.loads(pf.read_text())
+    except (OSError, ValueError):
+        return None
 
+
+def start_server(model: Path, server_bin: Path, threads: int,
+                 wait: float = 180.0, quiet: bool = False,
+                 port: int | None = None, ctx_size: int = 2048) -> int:
     # The UNIX socket is preferred (see _UnixHTTPConnection), but older
     # llama-server builds read --host as a hostname and fail to bind, so the
     # transport has to be settable. TCP is safe only when its socket owner can
@@ -487,6 +499,28 @@ def start_server(model: Path, server_bin: Path, threads: int,
     if not use_socket and not _can_inspect_sockets():
         raise RuntimeError(_TCP_INSPECTION_ERROR)
 
+    requested = {
+        "model": str(model),
+        "server_bin": str(server_bin),
+        "threads": threads,
+        "ctx_size": ctx_size,
+        "port": port,
+        "use_socket": use_socket,
+    }
+    recorded = _read_params()
+    # A resident server may only be reused when it was launched with the exact
+    # parameters being requested. --port/--threads/--model/--ctx-size would
+    # otherwise be silently ignored on every query after the first one. A
+    # server with no recorded params is a legacy/unknown launch, which we keep
+    # reusing as before.
+    if recorded is None or recorded == requested:
+        if use_socket and _sock_path().exists() and _alive():
+            return 0
+        if (existing := running_port()) is not None:
+            return existing
+    if recorded is not None:
+        stop_server()
+
     sd = _state_dir()
     log = sd / "server.log"
 
@@ -495,16 +529,18 @@ def start_server(model: Path, server_bin: Path, threads: int,
     token = secrets.token_urlsafe(24)
     _write_private(_token_path(), token)
 
-    if use_socket:
+    if use_socket and port is None:
         sp = _sock_path()
         sp.unlink(missing_ok=True)
         port = 0
         cmd = [str(server_bin), "-m", str(model), "--host", str(sp),
-               "-t", str(threads), "-c", "2048", "--no-webui"]
+               "-t", str(threads), "-c", str(ctx_size), "--no-webui"]
     else:
-        port = _free_port()
-        cmd = [str(server_bin), "-m", str(model), "--host", HOST, "--port", str(port),
-               "-t", str(threads), "-c", "2048", "--no-webui"]
+        if port is None:
+            port = _free_port()
+        cmd = [str(server_bin), "-m", str(model), "--host", HOST,
+               "--port", str(port), "-t", str(threads), "-c", str(ctx_size),
+               "--no-webui"]
     # The server log records the launch command line and can contain prompt
     # text; it gets the same owner-only treatment as the pid and token.
     log_flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
@@ -538,6 +574,7 @@ def start_server(model: Path, server_bin: Path, threads: int,
         if _alive(port or None, expected_pid=proc.pid if port else None):
             if not quiet:
                 print(" ready.", file=sys.stderr, flush=True)
+            _write_private(_params_file(), json.dumps(requested))
             return port
         time.sleep(0.3)
     raise RuntimeError(f"llama-server did not become ready in {wait:.0f}s; see {log}")
@@ -802,7 +839,8 @@ def _query_remote(remote: dict, prompt: str, cfg: dict, n: int,
 
 def _query_oneshot(model: Path, cli_bin: Path, prompt: str, cfg: dict, threads: int,
                    system: str | None = None,
-                   grammar: str | None = None) -> list[str]:
+                   grammar: str | None = None,
+                   ctx_size: int = 2048) -> list[str]:
     """One-shot generation via a single llama-cli invocation.
 
     The prompt, system prompt and grammar all go through 0o600 temp files, not
@@ -824,7 +862,8 @@ def _query_oneshot(model: Path, cli_bin: Path, prompt: str, cfg: dict, threads: 
         cmd = [str(cli_bin), "-m", str(model), "--file", prm_file.name,
                "-st", "--no-display-prompt", "--no-warmup",
                "--temp", str(cfg.get("temperature", 0.0)),
-               "-n", str(cfg.get("max_tokens", 64)), "-t", str(threads)]
+               "-n", str(cfg.get("max_tokens", 64)), "-t", str(threads),
+               "-c", str(ctx_size)]
 
         cmd.extend(["--system-prompt-file", sys_file.name])
 
@@ -985,7 +1024,9 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
 
     t0 = time.time()
     if server_bin is not None:
-        port = start_server(model, server_bin, threads, quiet=quiet)
+        port = start_server(model, server_bin, threads, quiet=quiet,
+                            port=cfg.get("server_port"),
+                            ctx_size=cfg.get("ctx_size", 2048))
         raws = _query_server(port, user_msg, cfg, n, system=system, grammar=grammar)
         mode = "server"
     else:
@@ -994,7 +1035,8 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
             raise FileNotFoundError(
                 "neither llama-server nor llama-cli found -- run `whatisit doctor`")
         raws = _query_oneshot(model, cli, user_msg, cfg, threads, system=system,
-                              grammar=grammar)
+                              grammar=grammar,
+                              ctx_size=cfg.get("ctx_size", 2048))
         mode = "oneshot"
 
     cmds = _collect_commands(raws, host_pkg)


### PR DESCRIPTION
## What
Adds per-invocation CLI flags and fixes the confirm-default prompt.

### New CLI flags
- `--port`, `--threads`, `--model`, `--ctx-size` override the saved config (and `WHATISIT_MODEL` for `--model`)
- `--no-host-context` disables host context independently of the config
- `--no-grammar` disables GBNF grammar independently of the config
- `--debug` prints the exact system/user prompt and GBNF grammar to stderr for diagnosing model failures

### Bug fix
- Fixes #28: confirm prompt now defaults to yes (`[Y/n]`, empty input = yes), matching `whatisit config --set confirm_execute=true`

### Config
New `DEFAULTS` keys: `server_port`, `ctx_size`, `use_grammar`.

## Why
Per-invocation flags let users override `--port`, `--threads`, `--model`, `--ctx-size` without editing the config file, which is useful for testing and one-off runs. The `--debug` flag provides visibility into what the model actually sees, making it much easier to diagnose why the 1.5B model misbehaves.

The confirm-default fix (#28) makes `whatisit` consistent with its own config option (`confirm_execute=true` means yes by default).

## How
- All flags are hand-parsed in `QueryArgs` (argparse is not used for the query path — see the docstring).
- Flags are applied to `cfg` in `cmd_query` before calling `engine.generate`.
- 282 tests pass; ruff clean.

Companion PR: [#31](https://github.com/ThorOdinson246/whatisit-nl2sh/pull/31) adds GBNF grammar and distro-aware postprocessing for install commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added command-line options for model, threads, port, context size, host context, grammar, and debug output.
  - Command-line settings can override configured defaults for individual queries.
  - Grammar processing can be enabled or disabled per query.
  - Debug mode displays prompt details and active grammar information.
  - Pressing Enter now accepts execution confirmation by default.
  - Added defaults for server port, context size, and grammar usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->