### PR TITLE
chore: coderabbit review on request, not every push

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,6 +23,11 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    # One review per push burns the hourly allowance fast: a single PR here
+    # arrived as 17 commits. Contributors can push freely; ask for a review
+    # with `@coderabbitai review` when the branch is ready to look at.
+    auto_incremental_review: false
+    auto_pause_after_reviewed_commits: 5
 
   path_instructions:
     - path: "whatisit_pkg/whatisit/safety.py"


### PR DESCRIPTION
Hit the hourly review limit. Every push to an open PR was triggering a fresh review, and one PR here arrived as 17 commits.

Reviews now run on request with `@coderabbitai review` instead of automatically on every push.
