### PR TITLE
chore: make coderabbit comments readable

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,6 +21,10 @@ reviews:
   # comment text, none of it addressed to a human reader.
   enable_prompt_for_ai_agents: false
   estimate_code_review_effort: false
+  # Walkthrough chrome: the file list and status notices repeat what the PR
+  # page already shows, and each one is another section to expand.
+  changed_files_summary: false
+  review_status: false
   # The label taxonomy is maintained by hand; a bot should not write to it.
   auto_apply_labels: false
   suggested_reviewers: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,6 +16,11 @@ reviews:
   poem: false
   in_progress_fortune: false
   sequence_diagrams: false
+  # Every inline finding otherwise carries a "Prompt for AI Agents" block
+  # restating it as instructions for a bot. Measured on one review: 42% of the
+  # comment text, none of it addressed to a human reader.
+  enable_prompt_for_ai_agents: false
+  estimate_code_review_effort: false
   # The label taxonomy is maintained by hand; a bot should not write to it.
   auto_apply_labels: false
   suggested_reviewers: false


### PR DESCRIPTION
Review comments are hard to read. On one review, 42% of the inline comment text was the "Prompt for AI Agents" block, which restates the finding as instructions for a bot.

Turns that off, plus the review-effort estimate. Keeps the assertive profile, since the findings themselves have been good.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review settings to streamline review output.
  * Disabled review effort estimates, changed-file summaries, status notices, and AI-agent prompt blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->