### PR TITLE
feat(engine): opt-in distro_guidance, decoupled from host_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,27 @@ whatisit list files changed in the last week
 | `-n N` | show N alternative commands instead of one |
 | `-q`, `--quiet` | print only the bare command, for `$(...)` substitution |
 | `-t`, `--timing` | report how long generation took |
+| `--distro-guidance` / `--no-distro-guidance` | constrain install commands to this distro's package manager, for this invocation |
 
 Nothing runs unless you pass `-e` and confirm at the prompt. Anything flagged
 `DANGER` is never auto-run at all. See [Safety](#safety) for what gets flagged
 and what the checker can't see.
+
+### Wrong package manager?
+
+If the model suggests `apt install` on Arch or `pacman -S` on Debian, turn on
+distro guidance:
+
+```bash
+whatisit config --set distro_guidance=true
+```
+
+This is opt-in because the full host-context prompt block measured slightly
+worse on the benchmark for the bundled 1.5B model. Guidance costs one short
+prefix-cached sentence: install requests are constrained by a grammar to your
+package manager (`pacman -S`, `apt install`, `dnf install`, ...), and any
+foreign syntax that still slips through is rewritten to yours afterwards.
+Per-invocation: `whatisit --distro-guidance install docker`.
 
 ```bash
 # use the result inline

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ whatisit config --set distro_guidance=true
 
 This is opt-in because the full host-context prompt block measured slightly
 worse on the benchmark for the bundled 1.5B model. Guidance costs one short
-prefix-cached sentence: install requests are constrained by a grammar to your
-package manager (`pacman -S`, `apt install`, `dnf install`, ...), and any
-foreign syntax that still slips through is rewritten to yours afterwards.
+prefix-cached sentence: on the local backends, install requests are constrained
+by a grammar to your package manager (`pacman -S`, `apt install`,
+`dnf install`, ...), and any foreign syntax that still slips through is
+rewritten to yours afterwards. Remote endpoints skip the grammar (not all of
+them accept the field) but keep the rewrite.
 Per-invocation: `whatisit --distro-guidance install docker`.
 
 ```bash

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -426,7 +426,7 @@ class TestQueryFlagsApply:
 
     def test_debug_shows_grammar_when_available(self, monkeypatch, tmp_path, capsys):
         self._isolate(monkeypatch, tmp_path)
-        # distro_guidance is the new grammar gate; an install-intent prompt is
+        # distro_guidance is the grammar gate; an install-intent prompt is
         # required for the debug view to show a grammar, mirroring generate().
         cli.main(["config", "--set", "distro_guidance=true"])
         capsys.readouterr()
@@ -437,11 +437,11 @@ class TestQueryFlagsApply:
                             pkg_line=False: ("SYS", p))
         monkeypatch.setattr(cli.engine.hostctx, "stable_facts",
                             lambda *a, **k: {"pkg": "pacman"})
-        monkeypatch.setattr(cli.engine.hostctx, "grammar_for_pkg",
-                            lambda pkg: "grammar-blob", raising=False)
+        # The REAL pacman grammar must appear in the debug output -- a stub
+        # would pass even if gating picked up the wrong manager or none.
         rc = cli.main(["--debug", "install", "docker"])
         assert rc == 0
         err = capsys.readouterr().err
         assert "--debug" in err
-        assert "grammar-blob" in err
+        assert 'install      ::= "pacman -S "' in err
         assert "install docker" in err

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -416,7 +416,8 @@ class TestQueryFlagsApply:
         monkeypatch.setattr(cli.engine, "generate",
                             lambda *a, **k: (["ls"], 0.01, "server"))
         monkeypatch.setattr(cli.engine.hostctx, "build",
-                            lambda p, enabled=True, cwd=None: ("SYS", p))
+                            lambda p, enabled=True, cwd=None, include_volatile=True,
+                            pkg_line=False: ("SYS", p))
         rc = cli.main(["--debug", "list", "files"])
         assert rc == 0
         err = capsys.readouterr().err
@@ -425,22 +426,22 @@ class TestQueryFlagsApply:
 
     def test_debug_shows_grammar_when_available(self, monkeypatch, tmp_path, capsys):
         self._isolate(monkeypatch, tmp_path)
-        cli.main(["config", "--set", "host_context=true"])
+        # distro_guidance is the new grammar gate; an install-intent prompt is
+        # required for the debug view to show a grammar, mirroring generate().
+        cli.main(["config", "--set", "distro_guidance=true"])
         capsys.readouterr()
         monkeypatch.setattr(cli.engine, "generate",
                             lambda *a, **k: (["ls"], 0.01, "server"))
         monkeypatch.setattr(cli.engine.hostctx, "build",
-                            lambda p, enabled=True, cwd=None: ("SYS", p))
+                            lambda p, enabled=True, cwd=None, include_volatile=True,
+                            pkg_line=False: ("SYS", p))
         monkeypatch.setattr(cli.engine.hostctx, "stable_facts",
                             lambda *a, **k: {"pkg": "pacman"})
-        # grammar_for_pkg may not exist (PR A vs PR B); if so, create a stub
-        # so the debug path can derive a grammar through the hasattr guard.
-        # raising=False restores the original after the test either way.
         monkeypatch.setattr(cli.engine.hostctx, "grammar_for_pkg",
                             lambda pkg: "grammar-blob", raising=False)
-        rc = cli.main(["--debug", "list", "files"])
+        rc = cli.main(["--debug", "install", "docker"])
         assert rc == 0
         err = capsys.readouterr().err
         assert "--debug" in err
         assert "grammar-blob" in err
-        assert "list files" in err
+        assert "install docker" in err

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -595,7 +595,7 @@ class TestGenerateDiscardsTruncatedCandidates:
 
         class CaptureHostCtx:
             @staticmethod
-            def build(prompt, enabled=True, cwd=None, include_volatile=True):
+            def build(prompt, enabled=True, cwd=None, include_volatile=True, pkg_line=False):
                 captured["include_volatile"] = include_volatile
                 return ("SYSTEM PROMPT", prompt)
 
@@ -720,7 +720,7 @@ class TestServerOverridesReachTheBoundary:
 
 class _FakeHostCtx:
     @staticmethod
-    def build(prompt, enabled=True, cwd=None, include_volatile=True):
+    def build(prompt, enabled=True, cwd=None, include_volatile=True, pkg_line=False):
         return ("SYSTEM PROMPT", prompt)
     @staticmethod
     def stable_facts():
@@ -957,7 +957,8 @@ class TestGenerateRemote:
     def _enable_remote(self, monkeypatch, remote):
         monkeypatch.setattr(cfg_mod, "remote_config", lambda cfg: remote)
         monkeypatch.setattr(engine.hostctx, "build",
-                            lambda p, enabled=True, cwd=None, include_volatile=True: ("SYS", p))
+                            lambda p, enabled=True, cwd=None, include_volatile=True,
+                            pkg_line=False: ("SYS", p))
 
     @pytest.mark.parametrize("kwargs", [{"quiet": True}, {"for_execution": True}])
     def test_remote_execution_paths_suppress_volatile_host_context(
@@ -966,7 +967,8 @@ class TestGenerateRemote:
         monkeypatch.setattr(cfg_mod, "remote_config", lambda cfg: remote)
         captured = {}
 
-        def capture_context(prompt, enabled=True, cwd=None, include_volatile=True):
+        def capture_context(prompt, enabled=True, cwd=None, include_volatile=True,
+                            pkg_line=False):
             captured["include_volatile"] = include_volatile
             return ("SYS", prompt)
 
@@ -1057,7 +1059,8 @@ class TestGenerateGrammarAndPostprocess:
 
         class FakeHost:
             @staticmethod
-            def build(prompt, enabled=True, cwd=None, include_volatile=True):
+            def build(prompt, enabled=True, cwd=None, include_volatile=True,
+                      pkg_line=False):
                 return ("SYS", prompt)
             @staticmethod
             def stable_facts():
@@ -1080,22 +1083,101 @@ class TestGenerateGrammarAndPostprocess:
             return [("pacman -S htop", "stop")]
         monkeypatch.setattr(engine, "_query_server", fake_query_server)
 
-        cmds, _, mode = engine.generate("install htop", {}, n=1)
+        cmds, _, mode = engine.generate("install htop", {"distro_guidance": True}, n=1)
         assert captured["grammar"] == "fake-grammar"
         assert mode == "server"
+
+    def test_no_grammar_by_default(self, monkeypatch, tmp_path):
+        """distro_guidance is opt-in: with defaults (and host_context off) no
+        GBNF is sent and no rewrite runs."""
+        self._fake_cfg_and_model(monkeypatch, tmp_path)
+
+        class FakeHost:
+            @staticmethod
+            def build(prompt, enabled=True, cwd=None, include_volatile=True,
+                      pkg_line=False):
+                captured["pkg_line"] = pkg_line
+                return ("SYS", prompt)
+            @staticmethod
+            def stable_facts():
+                raise AssertionError("stable_facts must not run with all guidance off")
+            @staticmethod
+            def grammar_for_pkg(pkg_mgr):
+                return "fake-grammar"
+            @staticmethod
+            def is_install_request(prompt):
+                return True
+            @staticmethod
+            def postprocess_command(cmd, pkg_mgr):
+                raise AssertionError("postprocess must not run with all guidance off")
+
+        monkeypatch.setattr(engine, "hostctx", FakeHost())
+        captured = {}
+        def fake_query_server(port, prompt, cfg, n, system=None, grammar=None):
+            captured["grammar"] = grammar
+            return [("apt install htop", "stop")]
+        monkeypatch.setattr(engine, "_query_server", fake_query_server)
+
+        cmds, _, _ = engine.generate("install htop",
+                                     {"host_context": False}, n=1)
+        assert captured["grammar"] is None
+        assert cmds == ["apt install htop"]
+
+    def test_grammar_without_host_context(self, monkeypatch, tmp_path):
+        """The regression behind issue #31: distro guidance must work on its
+        own -- host_context stays off (its measured harm), yet install prompts
+        are still constrained to the host package manager and rewritten."""
+        self._fake_cfg_and_model(monkeypatch, tmp_path)
+
+        class FakeHost:
+            @staticmethod
+            def build(prompt, enabled=True, cwd=None, include_volatile=True,
+                      pkg_line=False):
+                captured["enabled"] = enabled
+                captured["pkg_line"] = pkg_line
+                return ("SYS", prompt)
+            @staticmethod
+            def stable_facts():
+                return {"pkg": "pacman"}
+            @staticmethod
+            def grammar_for_pkg(pkg_mgr):
+                return "fake-grammar"
+            @staticmethod
+            def is_install_request(prompt):
+                return "install" in prompt
+            @staticmethod
+            def postprocess_command(cmd, pkg_mgr):
+                return cmd.replace("apt-get install -y", "pacman -S")
+
+        monkeypatch.setattr(engine, "hostctx", FakeHost())
+        captured = {}
+        def fake_query_server(port, prompt, cfg, n, system=None, grammar=None):
+            captured["grammar"] = grammar
+            return [("apt-get install -y htop", "stop")]
+        monkeypatch.setattr(engine, "_query_server", fake_query_server)
+
+        cfg = {"distro_guidance": True, "host_context": False}
+        cmds, _, _ = engine.generate("install htop", cfg, n=1)
+        assert captured["grammar"] == "fake-grammar"
+        assert captured["enabled"] is False      # full facts block stayed off
+        assert captured["pkg_line"] is True      # one-line guidance went instead
+        assert cmds == ["pacman -S htop"]
 
     def test_postprocesses_wrong_distro_syntax(self, monkeypatch, tmp_path):
         self._fake_cfg_and_model(monkeypatch, tmp_path)
         # Drive postprocessing with the real implementation, pinned to pacman.
-        monkeypatch.setattr(engine.hostctx, "build",
-                            lambda p, enabled=True, cwd=None, include_volatile=True: ("SYS", p))
+        monkeypatch.setattr(
+            engine.hostctx, "build",
+            lambda p, enabled=True, cwd=None, include_volatile=True,
+            pkg_line=False: ("SYS", p))
         monkeypatch.setattr(engine.hostctx, "stable_facts",
                             lambda *a, **k: {"pkg": "pacman"})
         monkeypatch.setattr(engine.hostctx, "grammar_for_pkg",
                             lambda pkg_mgr: None)
         monkeypatch.setattr(engine, "_query_server",
                             lambda *a, **k: [("apt-get install -y htop", "stop")])
-        cmds, _, _ = engine.generate("install htop", {}, n=1)
+        cfg = {"distro_guidance": True, "host_context": False}
+        cmds, _, _ = engine.generate("install htop", cfg, n=1)
         assert cmds == ["pacman -S htop"]
 
     def test_oneshot_passes_prompts_and_grammar_via_files(self, monkeypatch, tmp_path):

--- a/whatisit_pkg/tests/test_hostctx.py
+++ b/whatisit_pkg/tests/test_hostctx.py
@@ -694,6 +694,13 @@ class TestGrammar:
         self._assert_accepts("pacman", "pacman -S libc++1")
         self._assert_accepts("brew", "brew install python3.11")
 
+    def test_dnf_pkg_names_with_digits(self):
+        """Regression: the dnf grammar's char class read [a-zA-Z0_9_.+-]
+        (`0_`, not `0-9`) -- it happened to accept letters by accident but was
+        not the intended class."""
+        self._assert_accepts("dnf", "dnf install python3.11")
+        self._assert_accepts("dnf", "sudo dnf install libxml2")
+
     def test_unknown_pkg_returns_none(self):
         assert hostctx.grammar_for_pkg("nonexistent") is None
 
@@ -820,3 +827,111 @@ class TestPostprocess:
     def test_multi_package_install(self):
         got = hostctx.postprocess_command("apt-get install htop nmon", "pacman")
         assert got == "pacman -S htop nmon"
+
+
+# ---------------------------------------------------------------------------
+# pkg_guidance_line() + build(pkg_line=...)
+# ---------------------------------------------------------------------------
+
+class TestPkgGuidanceLine:
+    def _facts(self, pkg):
+        return {"pkg": pkg, "distro": "Arch Linux", "distro_version": "",
+                "arch": "x86_64", "shell": "zsh", "present": [], "missing": []}
+
+    def test_names_the_pkg_manager(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+        line = hostctx.pkg_guidance_line(self._facts("pacman"))
+        assert "pacman" in line
+
+    def test_unknown_pkg_returns_empty(self):
+        assert hostctx.pkg_guidance_line(self._facts("unknown")) == ""
+
+    def test_does_not_name_foreign_managers(self):
+        """stable_block()'s note: naming a banned tool primes a small model
+        toward it. The guidance line must mention only the host's manager."""
+        line = hostctx.pkg_guidance_line(self._facts("pacman"))
+        for foreign in ("apt", "dnf", "yum", "zypper", "apk", "brew"):
+            assert foreign not in line
+
+    def test_front_loads_the_manager_name(self):
+        """The shipped 1.5B model weighs early tokens heavily: the manager
+        name must appear in the first sentence half, not the tail."""
+        line = hostctx.pkg_guidance_line(self._facts("dnf"))
+        first_half = line[:len(line) // 2]
+        assert "dnf" in first_half
+
+    def test_byte_stable_across_calls(self, monkeypatch, tmp_path):
+        """The line joins the prefix-cached system prompt; it must be
+        deterministic so the cache stays valid."""
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+        facts = self._facts("apt")
+        assert hostctx.pkg_guidance_line(facts) == hostctx.pkg_guidance_line(facts)
+
+    def test_uses_real_facts_when_none_given(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+        monkeypatch.setattr(hostctx, "_distro_info",
+                            lambda: {"id": "arch", "name": "Arch Linux",
+                                     "version": "", "version_id": "",
+                                     "id_like": []})
+        monkeypatch.setattr(hostctx.shutil, "which",
+                            lambda x: x == "pacman")
+        monkeypatch.setattr(hostctx.platform, "system", lambda: "Linux")
+        line = hostctx.pkg_guidance_line()
+        assert "pacman" in line
+
+
+class TestBuildPkgLine:
+    """build(pkg_line=True) folds in only the one-line guidance -- the opt-in
+    distro_guidance mode that keeps the measured-harmful facts block off."""
+
+    def _probe_pacman(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+        monkeypatch.setattr(hostctx, "_distro_info",
+                            lambda: {"id": "arch", "name": "Arch Linux",
+                                     "version": "", "version_id": "",
+                                     "id_like": []})
+        monkeypatch.setattr(hostctx.shutil, "which", lambda x: x == "pacman")
+        monkeypatch.setattr(hostctx.platform, "system", lambda: "Linux")
+
+    def test_pkg_line_appended_without_facts_block(self, monkeypatch, tmp_path):
+        self._probe_pacman(monkeypatch, tmp_path)
+        system, user = hostctx.build("install numpy", enabled=False,
+                                     include_volatile=False, pkg_line=True)
+        assert "<host_environment>" not in system
+        assert "<constraint>" in system
+        assert "pacman" in system
+        assert user == "install numpy"
+
+    def test_pkg_line_keeps_volatile_out_of_the_system_prompt(self, monkeypatch, tmp_path):
+        """The guidance line joins the cached prefix; volatile facts must stay
+        on the user side exactly as with the full facts block."""
+        self._probe_pacman(monkeypatch, tmp_path)
+        monkeypatch.chdir(tmp_path)
+        system, user = hostctx.build("list files", enabled=False, pkg_line=True)
+        assert "Working directory" not in system
+        assert "Working directory" in user
+
+    def test_no_line_when_pkg_unknown(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+        monkeypatch.setattr(hostctx, "_distro_info",
+                            lambda: {"id": "nixos", "name": "NixOS",
+                                     "version": "", "version_id": "",
+                                     "id_like": []})
+        monkeypatch.setattr(hostctx.shutil, "which", lambda x: False)
+        monkeypatch.setattr(hostctx.platform, "system", lambda: "Linux")
+        system, user = hostctx.build("install numpy", enabled=False,
+                                     include_volatile=False, pkg_line=True)
+        assert system == cfg_mod.SYSTEM_PROMPT
+        assert user == "install numpy"
+
+    def test_full_block_subsumes_the_line(self, monkeypatch, tmp_path):
+        self._probe_pacman(monkeypatch, tmp_path)
+        system, _ = hostctx.build("install numpy", enabled=True, pkg_line=True)
+        assert "<host_environment>" in system
+        # exactly one constraint mentioning pacman comes from stable_block()
+        assert system.count("This machine manages packages") == 0
+
+    def test_disabled_and_no_pkg_line_is_plain(self):
+        system, user = hostctx.build("install numpy", enabled=False, pkg_line=False)
+        assert system == cfg_mod.SYSTEM_PROMPT
+        assert user == "install numpy"

--- a/whatisit_pkg/tests/test_hostctx.py
+++ b/whatisit_pkg/tests/test_hostctx.py
@@ -838,10 +838,14 @@ class TestPkgGuidanceLine:
         return {"pkg": pkg, "distro": "Arch Linux", "distro_version": "",
                 "arch": "x86_64", "shell": "zsh", "present": [], "missing": []}
 
-    def test_names_the_pkg_manager(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
-        line = hostctx.pkg_guidance_line(self._facts("pacman"))
-        assert "pacman" in line
+    def test_exact_constraint_text_for_pacman(self):
+        """The line joins the cached system prompt: pin its full wording so an
+        accidental edit cannot silently change what every host sends."""
+        expected = ("<constraint>\n"
+                    "This machine manages packages exclusively with pacman; "
+                    "install, update, and remove software only with pacman.\n"
+                    "</constraint>")
+        assert hostctx.pkg_guidance_line(self._facts("pacman")) == expected
 
     def test_unknown_pkg_returns_empty(self):
         assert hostctx.pkg_guidance_line(self._facts("unknown")) == ""

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -149,8 +149,8 @@ def cmd_query(args, cfg: dict) -> int:
         # Show the exact prompt sent to the model and the active GBNF grammar
         # (if any). Intended for diagnosing why the 1.5B model misbehaves; goes
         # to stderr so `-q` output is unaffected. Mirrors generate()'s gating:
-        # the grammar needs distro_guidance OR host_context, plus use_grammar
-        # and an install-intent prompt.
+        # the grammar needs distro_guidance, use_grammar, and an install-intent
+        # prompt -- host_context alone does not send one.
         guidance_on = cfg.get("distro_guidance", False)
         context_on = cfg.get("host_context", True)
         system, user_msg = engine.hostctx.build(
@@ -159,7 +159,7 @@ def cmd_query(args, cfg: dict) -> int:
             pkg_line=guidance_on)
         pkg = "unknown"
         grammar = None
-        if (guidance_on or context_on) and cfg.get("use_grammar", True):
+        if guidance_on and cfg.get("use_grammar", True):
             try:
                 pkg = engine.hostctx.stable_facts().get("pkg", "unknown")
             except OSError:

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -143,20 +143,28 @@ def cmd_query(args, cfg: dict) -> int:
         cfg["host_context"] = args.host_context
     if args.grammar is not None:
         cfg["use_grammar"] = args.grammar
+    if args.distro_guidance is not None:
+        cfg["distro_guidance"] = args.distro_guidance
     if args.debug:
         # Show the exact prompt sent to the model and the active GBNF grammar
         # (if any). Intended for diagnosing why the 1.5B model misbehaves; goes
-        # to stderr so `-q` output is unaffected.
-        system, user_msg = engine.hostctx.build(prompt,
-                                                enabled=cfg.get("host_context", True))
+        # to stderr so `-q` output is unaffected. Mirrors generate()'s gating:
+        # the grammar needs distro_guidance OR host_context, plus use_grammar
+        # and an install-intent prompt.
+        guidance_on = cfg.get("distro_guidance", False)
+        context_on = cfg.get("host_context", True)
+        system, user_msg = engine.hostctx.build(
+            prompt, enabled=context_on,
+            include_volatile=not (args.quiet or args.execute),
+            pkg_line=guidance_on)
         pkg = "unknown"
         grammar = None
-        if cfg.get("host_context", True) and cfg.get("use_grammar", True):
+        if (guidance_on or context_on) and cfg.get("use_grammar", True):
             try:
                 pkg = engine.hostctx.stable_facts().get("pkg", "unknown")
             except OSError:
                 pass
-            if pkg != "unknown" and hasattr(engine.hostctx, "grammar_for_pkg"):
+            if pkg != "unknown" and engine.hostctx.is_install_request(prompt):
                 grammar = engine.hostctx.grammar_for_pkg(pkg)
         _emit_debug(prompt, system, user_msg, grammar)
 
@@ -729,6 +737,11 @@ def build_parser() -> argparse.ArgumentParser:
                     help="enable the GBNF grammar for this invocation")
     ap.add_argument("--no-grammar", dest="grammar", action="store_false",
                     help="disable the GBNF grammar for this invocation")
+    ap.add_argument("--distro-guidance", dest="distro_guidance", action="store_true",
+                    help="constrain install commands to this distro's package "
+                         "manager for this invocation")
+    ap.add_argument("--no-distro-guidance", dest="distro_guidance", action="store_false",
+                    help="disable distro guidance for this invocation")
     ap.add_argument("--debug", action="store_true",
                     help="print the exact prompt and grammar sent to the model")
 
@@ -762,7 +775,9 @@ def build_parser() -> argparse.ArgumentParser:
 SUBCOMMANDS = {"setup", "doctor", "stop", "config"}
 _FLAGS_NOARG = {"-e", "--execute", "-q", "--quiet", "-t", "--timing", "--oneshot",
                 "--host-context", "--no-host-context",
-                "--grammar", "--no-grammar", "--debug", "-y", "--yes"}
+                "--grammar", "--no-grammar",
+                "--distro-guidance", "--no-distro-guidance",
+                "--debug", "-y", "--yes"}
 _FLAGS_ARG = {"-n", "--num"}
 _FLAGS_QUERY_ARG = {"--port", "--threads", "--ctx-size", "--model"}
 
@@ -786,6 +801,7 @@ class QueryArgs:
         self.timing, self.oneshot = False, False
         self.port, self.threads, self.ctx_size, self.model = None, None, None, None
         self.host_context, self.grammar, self.debug, self.yes = None, None, False, False
+        self.distro_guidance = None
         i = 0
         while i < len(argv):
             a = argv[i]
@@ -801,6 +817,10 @@ class QueryArgs:
                     self.grammar = True
                 elif a == "--no-grammar":
                     self.grammar = False
+                elif a == "--distro-guidance":
+                    self.distro_guidance = True
+                elif a == "--no-distro-guidance":
+                    self.distro_guidance = False
                 elif a in ("-y", "--yes"):
                     self.yes = True
                 else:

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -101,10 +101,13 @@ DEFAULTS = {
     "host_context": False,
     # OFF by default (opt-in). Keeps the full host-facts prompt block out of the
     # way of the shipped model's measured regression, while still fixing the
-    # wrong-distro failure: when on, install prompts are GBNF-constrained to the
-    # host package manager and every candidate command is regex-rewritten from
-    # foreign syntax as a backstop. Costs one short prefix-cached line. Enable
-    # if whatisit suggests `apt install` on Arch, `pacman -S` on Debian, etc.
+    # wrong-distro failure: when on, install prompts are GBNF-constrained to
+    # the host package manager on the local backends (llama-server /
+    # llama-cli), and every candidate command is regex-rewritten from foreign
+    # syntax as a backstop everywhere -- remote endpoints included, though they
+    # get no grammar field on the wire. Costs one short prefix-cached line.
+    # Enable if whatisit suggests `apt install` on Arch, `pacman -S` on Debian,
+    # etc.
     "distro_guidance": False,
     # GBNF grammar constraint for install prompts. When on (default) and the
     # host's package manager is known, the model is constrained to that manager's

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -99,6 +99,13 @@ DEFAULTS = {
     # OFF by default. It is cheap (prefix-cached) but MEASURED HARMFUL on the
     # only benchmark available: 54.2% -> 45.1% pass, p=0.0004. See hostctx.py.
     "host_context": False,
+    # OFF by default (opt-in). Keeps the full host-facts prompt block out of the
+    # way of the shipped model's measured regression, while still fixing the
+    # wrong-distro failure: when on, install prompts are GBNF-constrained to the
+    # host package manager and every candidate command is regex-rewritten from
+    # foreign syntax as a backstop. Costs one short prefix-cached line. Enable
+    # if whatisit suggests `apt install` on Arch, `pacman -S` on Debian, etc.
+    "distro_guidance": False,
     # GBNF grammar constraint for install prompts. When on (default) and the
     # host's package manager is known, the model is constrained to that manager's
     # install syntax. --no-grammar disables only the constraint; distro-aware

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -963,6 +963,28 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
     mode is one of "remote", "server", or "oneshot". Remote mode is selected by
     a configured OpenAI-compatible base URL and needs no local model at all.
     """
+    # Distro guidance (opt-in) and host context both need the host package
+    # manager: guidance uses it for the GBNF grammar and the rewrite backstop,
+    # host context for the full facts block. The grammar is gated on BOTH
+    # install-intent and use_grammar (--no-grammar turns only the constraint
+    # off), so a GBNF that rejects a valid command form must not disable the
+    # rewrite path, and a non-install query is never grammar-constrained at
+    # all. Crucially, the grammar and the rewrite do NOT require host_context:
+    # the facts block is measured harmful on the shipped model, but grammar +
+    # regex cost no tokens and fix a real failure class on their own.
+    guidance_on = bool(cfg.get("distro_guidance", False))
+    context_on = bool(cfg.get("host_context", True))
+    host_pkg = "unknown"
+    if guidance_on or context_on:
+        try:
+            host_pkg = hostctx.stable_facts().get("pkg", "unknown")
+        except (OSError, UnicodeDecodeError):
+            pass
+    grammar = None
+    if (guidance_on and cfg.get("use_grammar", True) and host_pkg != "unknown"
+            and hostctx.is_install_request(prompt)):
+        grammar = hostctx.grammar_for_pkg(host_pkg)
+
     remote = cfg_mod.remote_config(cfg)
     if remote is not None:
         if not remote["model"]:
@@ -976,11 +998,14 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
         # cwd, which the user did not type, so it is withheld from the two
         # flows whose output can run. Ordinary suggestions still get it.
         system, user_msg = hostctx.build(
-            prompt, enabled=cfg.get("host_context", True),
-            include_volatile=not (for_execution or quiet))
+            prompt, enabled=context_on,
+            include_volatile=not (for_execution or quiet), pkg_line=guidance_on)
         t0 = time.time()
+        # No `grammar` wire field here: llama-server accepts it, but generic
+        # OpenAI-compatible endpoints may reject unknown fields outright. The
+        # postprocess rewrite below remains the backstop on this path.
         raws = _query_remote(remote, user_msg, cfg, n, system=system)
-        return _collect_commands(raws), time.time() - t0, "remote"
+        return _collect_commands(raws, host_pkg), time.time() - t0, "remote"
 
     model = cfg_mod.find_model()
     if model is None:
@@ -997,30 +1022,13 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
         elif (c := Path(cfg.get("llama_server", "/nonexistent"))).exists():
             server_bin = c
 
-    # Host context defaults ON: it is prefix-cached, so it costs one-time
-    # prefill rather than per-query latency, and it removed a whole class of
-    # placeholder / wrong-tool failures. cfg["host_context"]=false disables it.
+    # Host context defaults ON when the key is absent (DEFAULTS sets it False);
+    # it is prefix-cached, so it costs one-time prefill rather than per-query
+    # latency. cfg["host_context"]=false disables it. distro_guidance folds in
+    # only the one-line package-manager sentence instead of the full block.
     system, user_msg = hostctx.build(
-        prompt, enabled=cfg.get("host_context", True),
-        include_volatile=not (for_execution or quiet))
-
-    # GBNF grammar + distro-aware postprocessing: constrain install verbs to the
-    # host's package manager and rewrite any wrong-distro syntax as a backstop.
-    # Host-package detection runs whenever host context is on -- it feeds the
-    # postprocess backstop. The grammar is gated on BOTH install-intent and
-    # use_grammar (--no-grammar turns only the constraint off), so a GBNF that
-    # turns out to reject a valid command form must not disable the rewrite
-    # path, and a non-install query is never grammar-constrained at all.
-    host_pkg = "unknown"
-    grammar = None
-    if cfg.get("host_context", True):
-        try:
-            host_pkg = hostctx.stable_facts().get("pkg", "unknown")
-        except (OSError, UnicodeDecodeError):
-            pass
-        if (cfg.get("use_grammar", True) and host_pkg != "unknown"
-                and hostctx.is_install_request(prompt)):
-            grammar = hostctx.grammar_for_pkg(host_pkg)
+        prompt, enabled=context_on,
+        include_volatile=not (for_execution or quiet), pkg_line=guidance_on)
 
     t0 = time.time()
     if server_bin is not None:

--- a/whatisit_pkg/whatisit/hostctx.py
+++ b/whatisit_pkg/whatisit/hostctx.py
@@ -516,14 +516,50 @@ def grammar_for_pkg(pkg_mgr: str) -> str | None:
     return PKG_MGR_GRAMMARS.get(pkg_mgr)
 
 
+def pkg_guidance_line(facts: dict | None = None) -> str:
+    """One stable sentence naming the host's package manager, or '' if unknown.
+
+    This is the distro_guidance alternative to the full facts block: the block
+    is measured harmful on the shipped model (see module docstring), but a
+    wrong-distro install command remains a real failure. Three constraints
+    shape the wording. The shipped model is small (Qwen2.5-1.5B finetune) and
+    weighs early tokens heavily, so the manager's name sits inside the first
+    few tokens rather than at the end of the line. Foreign package managers
+    are deliberately NOT named -- see the note in stable_block(): naming a
+    wrong tool, even to ban it, primes a small model toward it. And the line
+    must be byte-identical per host, because it joins the prefix-cached system
+    prompt; any per-query variation would turn the once-per-session prefill
+    cost into a per-query one.
+    """
+    f = facts or stable_facts()
+    pkg = f.get("pkg", "unknown")
+    if pkg == "unknown":
+        return ""
+    return ("<constraint>\n"
+            f"This machine manages packages exclusively with {pkg}; "
+            f"install, update, and remove software only with {pkg}.\n"
+            "</constraint>")
+
+
 def build(prompt: str, enabled: bool = True, cwd: Path | None = None,
-          include_volatile: bool = True) -> tuple[str, str]:
-    """Return (system_prompt, user_message) with context folded in."""
-    if not enabled:
+          include_volatile: bool = True, pkg_line: bool = False) -> tuple[str, str]:
+    """Return (system_prompt, user_message) with context folded in.
+
+    pkg_line folds in just pkg_guidance_line() instead of the full block, for
+    the opt-in distro_guidance mode. It has no effect when the full block is
+    already enabled (the block subsumes the line).
+    """
+    if not enabled and not pkg_line:
         return cfg_mod.SYSTEM_PROMPT, prompt
-    system = cfg_mod.SYSTEM_PROMPT + "\n\n" + stable_block()
+    parts = [cfg_mod.SYSTEM_PROMPT]
+    if enabled:
+        parts.append(stable_block())
+    else:
+        line = pkg_guidance_line()
+        if line:
+            parts.append(line)
     if include_volatile:
         user = volatile_block(cwd) + "\n\n<request>\n" + prompt + "\n</request>"
     else:
         user = prompt
-    return system, user
+    return "\n\n".join(parts), user

--- a/whatisit_pkg/whatisit/hostctx.py
+++ b/whatisit_pkg/whatisit/hostctx.py
@@ -467,7 +467,7 @@ root         ::= command ("\n" command)* "\n"?
 command      ::= sudo-install | install
 sudo-install ::= "sudo " install
 install      ::= "dnf install " pkg-name (" " pkg-name)*
-pkg-name     ::= [a-zA-Z0_9_.+-]+
+pkg-name     ::= [a-zA-Z0-9_.+-]+
 ''',
     "apk": r'''
 root         ::= command ("\n" command)* "\n"?


### PR DESCRIPTION
## What does this change do, and why?

On my Archcraft machine, `whatisit install htop` kept answering `sudo apt-get install htop`, even after #31. While digging into why, I found the distro-aware machinery from #31 is effectively unreachable: everything in `generate()` — the GBNF grammar, and even the regex rewrite backstop — sits behind `host_context`, which defaults to **off** (deliberately, per the benchmark regression). So with a default config none of it ever runs. I reproduced this end to end before touching anything.

This PR adds an opt-in `distro_guidance` config key that decouples the zero-cost parts from the measured-harmful one:

- **Grammar + rewrite run whenever `distro_guidance` is on** — no `host_context` required. The grammar stays gated on `use_grammar` and install-intent as before.
- Instead of the full facts block, guidance folds **one short `<constraint>` sentence** into the system prompt ("This machine manages packages exclusively with pacman; ..."). It's byte-identical per host, so it stays inside the prefix cache.
- The wording follows the two constraints noted in the code: foreign managers are deliberately *not* named (naming banned tools primes small models toward them), and the manager name sits in the first few tokens since the 1.5B model weights early tokens heavily.
- Remote mode gets the rewrite backstop but no `grammar` wire field — generic OpenAI-compatible endpoints may reject unknown fields outright.
- Small drive-by fix: the dnf grammar's char class read `[a-zA-Z0_9_.+-]` where `0-9` was meant.

Per-invocation flags follow the existing `--grammar` pattern: `--distro-guidance` / `--no-distro-guidance`.

## How I tested it

Real machine test (Archcraft, bundled 1.5B model, resident server):

```
$ whatisit --no-distro-guidance install htop     # baseline
sudo apt-get install htop                        # the bug

$ whatisit --distro-guidance install htop
pacman -S htop                                   # grammar path

$ whatisit --distro-guidance --no-grammar install docker
pacman -S docker                                 # rewrite backstop alone
```

Archcraft itself was a good check for the canonicalization: `ID=archcraft` isn't in the map but `ID_LIKE=arch` resolves to `pacman`. Non-install queries are untouched by the flag, and `--debug` reflects the new gating exactly. Config persistence via `whatisit config --set distro_guidance=true` works; my own config was restored afterwards.

Suite: 343 passed. One pre-existing failure (`TestCmdQueryQuietDangerRefusal::test_execute_marks_generation_as_execution_intended`) also fails on pristine master — unrelated to this PR, but worth a look separately since that test currently executes a real command instead of refusing at the no-tty gate.

## Notes for review

- Default behavior is unchanged: nothing runs unless the user opts in via config or flag.
- Known looseness (pre-existing, not addressed here): `pkg-name` accepts leading dashes, so the grammar can admit something like `-y` as a "package name". Happy to tighten that in a follow-up if wanted.
- Kept the commits small (fix / engine / cli / docs) since they touch mostly separate files; happy to squash if you'd rather have one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional distribution-aware guidance for package installation commands.
  * Added `--distro-guidance` and `--no-distro-guidance` command-line options.
  * Added configuration support, disabled by default.
  * Guidance can be enabled independently from full host-environment details.

* **Bug Fixes**
  * Improved recognition of DNF package names containing underscores, digits, and dots.

* **Documentation**
  * Added usage instructions, configuration examples, and per-invocation guidance examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->