### PR TITLE
feat(engine): lazy idle unload via --sleep-idle-seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ whatisit list files changed in the last week
 | `-n N` | show N alternative commands instead of one |
 | `-q`, `--quiet` | print only the bare command, for `$(...)` substitution |
 | `-t`, `--timing` | report how long generation took |
+| `--sleep-idle-seconds N` | stop the resident model server after N idle seconds, freeing its RAM (0 = never, default) |
+
+The resident server holds the model in RAM between queries so answers feel
+instant. On a memory-constrained box you can have it unload itself when idle:
+
+```bash
+whatisit --sleep-idle-seconds 300 show disk usage
+```
+
+The idle check is lazy: it runs at your next invocation, so a server that goes
+unused is stopped by the first query that arrives after the deadline (which
+then starts fresh). Persist it with `whatisit config --set sleep_idle_seconds=300`.
 
 Nothing runs unless you pass `-e` and confirm at the prompt. Anything flagged
 `DANGER` is never auto-run at all. See [Safety](#safety) for what gets flagged

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -444,3 +444,61 @@ class TestQueryFlagsApply:
         assert "--debug" in err
         assert "grammar-blob" in err
         assert "list files" in err
+
+
+# ------------------------------------------------------- --sleep-idle-seconds (#42)
+
+def test_sleep_idle_seconds_flag_parse():
+    a = cli.QueryArgs(["--sleep-idle-seconds", "300", "list", "files"])
+    assert a.sleep_idle_seconds == 300
+    assert a.words == ["list", "files"]
+
+
+def test_sleep_idle_seconds_defaults_to_none():
+    assert cli.QueryArgs(["list", "files"]).sleep_idle_seconds is None
+
+
+def test_sleep_idle_seconds_needs_value():
+    with pytest.raises(ValueError):
+        cli.QueryArgs(["--sleep-idle-seconds"])
+
+
+def test_sleep_idle_seconds_range_is_validated():
+    with pytest.raises(ValueError, match=">= 0"):
+        cli.QueryArgs(["--sleep-idle-seconds", "-1", "list", "files"])
+    assert cli.QueryArgs(["--sleep-idle-seconds", "0",
+                          "list", "files"]).sleep_idle_seconds == 0
+
+
+def test_sleep_idle_seconds_is_flagged_when_stray():
+    a = cli.QueryArgs(["list", "files", "--sleep-idle-seconds", "300"])
+    assert a.sleep_idle_seconds is None
+    assert a.stray_flags == ["--sleep-idle-seconds"]
+
+
+def test_sleep_idle_seconds_overrides_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+    seen = {}
+    def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                      for_execution=False):
+        seen["cfg"] = dict(cfg)
+        return (["ls"], 0.01, "server")
+    monkeypatch.setattr(cli.engine, "generate", fake_generate)
+    rc = cli.main(["--sleep-idle-seconds", "300", "list", "files"])
+    assert rc == 0
+    assert seen["cfg"]["sleep_idle_seconds"] == 300
+
+
+def test_sleep_idle_seconds_absent_leaves_config_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+    seen = {}
+    def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                      for_execution=False):
+        seen["cfg"] = dict(cfg)
+        return (["ls"], 0.01, "server")
+    monkeypatch.setattr(cli.engine, "generate", fake_generate)
+    cli.main(["list", "files"])
+    # The default comes from DEFAULTS (0 = never unload), not from the flag.
+    assert seen["cfg"]["sleep_idle_seconds"] == 0

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -9,6 +9,7 @@ import os
 import socket
 import stat
 import sys
+import time
 import urllib.error
 import urllib.request
 
@@ -1130,3 +1131,157 @@ class TestGenerateGrammarAndPostprocess:
         for flag in ("--file", "--system-prompt-file", "--grammar-file"):
             path = cmd[cmd.index(flag) + 1]
             assert not os.path.exists(path)
+
+
+# ------------------------------------------------------------- idle unload (#42)
+
+class TestIdleStop:
+    """--sleep-idle-seconds: lazy unload of the resident llama-server.
+
+    There is no daemon to watch the clock, so staleness is only discovered on
+    the next invocation; these tests pin down exactly when idle_stop() fires,
+    what it must ignore, and that touch_last_use() only writes while the
+    feature is enabled.
+    """
+
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+
+    def _seed_running_server(self, last_use_age):
+        sd = engine._state_dir()
+        (sd / "server.pid").write_text("12345\n")
+        if last_use_age is not None:
+            ts = time.time() - last_use_age
+            (sd / "server.last_use").write_text(f"{ts:.6f}\n")
+
+    def test_disabled_is_always_a_noop(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        self._seed_running_server(last_use_age=99999.0)
+        for disabled in (0, None, -5):
+            assert engine.idle_stop(disabled) is False
+            assert (engine._state_dir() / "server.pid").exists()
+
+    def test_stale_server_is_stopped(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        self._seed_running_server(last_use_age=301.0)
+        stopped = []
+        monkeypatch.setattr(engine, "stop_server", lambda: stopped.append(1) or True)
+        assert engine.idle_stop(300) is True
+        assert stopped == [1]
+
+    def test_fresh_server_is_kept(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        self._seed_running_server(last_use_age=10.0)
+        stopped = []
+        monkeypatch.setattr(engine, "stop_server", lambda: stopped.append(1))
+        assert engine.idle_stop(300) is False
+        assert stopped == []
+
+    def test_no_timestamp_means_no_stop(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        self._seed_running_server(last_use_age=None)
+        monkeypatch.setattr(engine, "stop_server",
+                            lambda: (_ for _ in ()).throw(AssertionError("no stop")))
+        assert engine.idle_stop(300) is False
+
+    def test_no_pid_file_means_no_stop(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        sd = engine._state_dir()
+        (sd / "server.last_use").write_text(f"{time.time() - 999:.6f}\n")
+        monkeypatch.setattr(engine, "stop_server",
+                            lambda: (_ for _ in ()).throw(AssertionError("no stop")))
+        assert engine.idle_stop(300) is False
+
+    def test_corrupt_timestamp_is_ignored_not_fatal(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        sd = engine._state_dir()
+        (sd / "server.pid").write_text("12345\n")
+        (sd / "server.last_use").write_text("not-a-number\n")
+        monkeypatch.setattr(engine, "stop_server",
+                            lambda: (_ for _ in ()).throw(AssertionError("no stop")))
+        assert engine.idle_stop(300) is False
+
+    def test_touch_writes_private_timestamp_when_enabled(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        engine.touch_last_use(300)
+        p = engine._last_use_path()
+        assert p.exists()
+        float(p.read_text())  # parses
+        assert stat.S_IMODE(os.stat(p).st_mode) == 0o600
+
+    def test_touch_is_a_noop_when_disabled(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        engine.touch_last_use(0)
+        assert not engine._last_use_path().exists()
+
+
+class TestIdleUnloadThroughGenerate:
+    """generate() must consult the idle deadline BEFORE start_server()'s reuse
+    check and refresh the timestamp after a successful server query."""
+
+    def _fake_cfg_and_model(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+        model = tmp_path / "model.gguf"
+        model.write_bytes(b"fake")
+        monkeypatch.setattr(cfg_mod, "find_model", lambda: model)
+        srv = tmp_path / "llama-server"
+        srv.write_bytes(b"fake")
+        monkeypatch.setenv("WHATISIT_LLAMA_SERVER", str(srv))
+
+    def _fake_hostctx_and_query(self, monkeypatch):
+        monkeypatch.setattr(engine, "hostctx", _FakeHostCtx())
+        monkeypatch.setattr(engine, "_query_server",
+                            lambda port, prompt, cfg, n, system=None, grammar=None:
+                                [("ls", "stop")])
+
+    def test_stale_server_stopped_before_start_and_touched_after(
+            self, monkeypatch, tmp_path):
+        self._fake_cfg_and_model(monkeypatch, tmp_path)
+        self._fake_hostctx_and_query(monkeypatch)
+        order = []
+        real_idle_stop = engine.idle_stop
+        monkeypatch.setattr(engine, "idle_stop",
+                            lambda secs: order.append(("idle_stop", secs))
+                            or real_idle_stop(secs))
+        monkeypatch.setattr(engine, "stop_server",
+                            lambda: order.append(("stop_server",)) or True)
+        monkeypatch.setattr(engine, "start_server",
+                            lambda *a, **kw: order.append(("start_server",)) or 12345)
+
+        sd = engine._state_dir()
+        (sd / "server.pid").write_text("12345\n")
+        (sd / "server.last_use").write_text(f"{time.time() - 400:.6f}\n")
+
+        _, _, mode = engine.generate("list files", {"sleep_idle_seconds": 300})
+        assert mode == "server"
+        # The stale server was stopped, and the idle check ran before
+        # start_server could reuse anything.
+        assert ("stop_server",) in order
+        assert order.index(("idle_stop", 300)) < order.index(("start_server",))
+        # The query refreshed the timestamp: it is now newer than the stale one.
+        assert float((sd / "server.last_use").read_text()) > time.time() - 30
+
+    def test_feature_off_never_touches_state(self, monkeypatch, tmp_path):
+        self._fake_cfg_and_model(monkeypatch, tmp_path)
+        self._fake_hostctx_and_query(monkeypatch)
+        called = []
+        monkeypatch.setattr(engine, "idle_stop",
+                            lambda secs: called.append(secs))
+        monkeypatch.setattr(engine, "start_server", lambda *a, **kw: 12345)
+        engine.generate("list files", {})
+        # generate() still calls idle_stop, but with the default of 0, which
+        # must be a complete no-op: nothing read, nothing written.
+        assert not engine._last_use_path().exists()
+
+    def test_oneshot_mode_does_not_write_timestamp(self, monkeypatch, tmp_path):
+        model = tmp_path / "model.gguf"
+        model.write_bytes(b"fake")
+        monkeypatch.setattr(cfg_mod, "find_model", lambda: model)
+        monkeypatch.setattr(engine, "hostctx", _FakeHostCtx())
+        monkeypatch.setattr(cfg_mod, "find_llama_cli", lambda: tmp_path / "llama-cli")
+        monkeypatch.setattr(engine, "_query_oneshot",
+                            lambda model, cli_bin, prompt, cfg, threads,
+                                   system=None, grammar=None, ctx_size=2048:
+                                [("ls", None)])
+        engine.generate("list files", {"sleep_idle_seconds": 300}, force_oneshot=True)
+        assert not engine._last_use_path().exists()

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -1201,6 +1201,8 @@ class TestIdleStop:
                             lambda: (_ for _ in ()).throw(AssertionError("no stop")))
         assert engine.idle_stop(300) is False
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="chmod is a no-op on Windows")
     def test_touch_writes_private_timestamp_when_enabled(self, monkeypatch, tmp_path):
         self._isolate(monkeypatch, tmp_path)
         engine.touch_last_use(300)
@@ -1274,6 +1276,9 @@ class TestIdleUnloadThroughGenerate:
         assert not engine._last_use_path().exists()
 
     def test_oneshot_mode_does_not_write_timestamp(self, monkeypatch, tmp_path):
+        # Isolate the state dir: the assertion itself calls _last_use_path(),
+        # which must not probe (or mkdir) the real data dir in a sandbox.
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
         model = tmp_path / "model.gguf"
         model.write_bytes(b"fake")
         monkeypatch.setattr(cfg_mod, "find_model", lambda: model)

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -139,6 +139,8 @@ def cmd_query(args, cfg: dict) -> int:
         cfg["server_port"] = args.port
     if args.ctx_size is not None:
         cfg["ctx_size"] = args.ctx_size
+    if args.sleep_idle_seconds is not None:
+        cfg["sleep_idle_seconds"] = args.sleep_idle_seconds
     if args.host_context is not None:
         cfg["host_context"] = args.host_context
     if args.grammar is not None:
@@ -719,6 +721,9 @@ def build_parser() -> argparse.ArgumentParser:
                     help="override saved thread count for this invocation")
     ap.add_argument("--ctx-size", type=int, metavar="N",
                     help="override the saved context size for this invocation")
+    ap.add_argument("--sleep-idle-seconds", type=int, metavar="N",
+                    help="stop the resident server after N idle seconds "
+                         "(checked on the next invocation; 0 = never, default 0)")
     ap.add_argument("--model", metavar="PATH",
                     help="override the registered model for this invocation")
     ap.add_argument("--host-context", dest="host_context", action="store_true",
@@ -764,7 +769,8 @@ _FLAGS_NOARG = {"-e", "--execute", "-q", "--quiet", "-t", "--timing", "--oneshot
                 "--host-context", "--no-host-context",
                 "--grammar", "--no-grammar", "--debug", "-y", "--yes"}
 _FLAGS_ARG = {"-n", "--num"}
-_FLAGS_QUERY_ARG = {"--port", "--threads", "--ctx-size", "--model"}
+_FLAGS_QUERY_ARG = {"--port", "--threads", "--ctx-size", "--model",
+                    "--sleep-idle-seconds"}
 
 
 class QueryArgs:
@@ -785,6 +791,7 @@ class QueryArgs:
         self.num, self.execute, self.quiet = 1, False, False
         self.timing, self.oneshot = False, False
         self.port, self.threads, self.ctx_size, self.model = None, None, None, None
+        self.sleep_idle_seconds = None
         self.host_context, self.grammar, self.debug, self.yes = None, None, False, False
         i = 0
         while i < len(argv):
@@ -830,6 +837,11 @@ class QueryArgs:
                     self.ctx_size = int(val)
                     if self.ctx_size <= 0:
                         raise ValueError(f"--ctx-size must be > 0, got {self.ctx_size}")
+                elif a == "--sleep-idle-seconds":
+                    self.sleep_idle_seconds = int(val)
+                    if self.sleep_idle_seconds < 0:
+                        raise ValueError(f"--sleep-idle-seconds must be >= 0, "
+                                         f"got {self.sleep_idle_seconds}")
                 else:
                     self.model = val
                 i += 1

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -110,6 +110,10 @@ DEFAULTS = {
     "force_tcp": False,
     "server_port": None,       # fixed TCP port for the resident server
     "ctx_size": 2048,          # context size passed to llama-server/llama-cli
+    # 0 => never auto-unload. When > 0, a resident llama-server that has been
+    # idle longer than this many seconds is stopped by the next invocation,
+    # freeing its RAM. See engine.idle_stop().
+    "sleep_idle_seconds": 0,
 }
 
 

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -487,6 +487,53 @@ def _read_params() -> dict | None:
         return None
 
 
+def _last_use_path() -> Path:
+    return _state_dir() / "server.last_use"
+
+
+def touch_last_use(sleep_idle_seconds) -> None:
+    """Record now as the server's last use, but only when idle unload is on.
+
+    Called after a successful server-mode query. When the feature is off
+    (sleep_idle_seconds <= 0) nothing is written, so the file never exists and
+    the idle check below is a no-op -- the default behaviour is unchanged.
+    """
+    if not sleep_idle_seconds or sleep_idle_seconds <= 0:
+        return
+    try:
+        _write_private(_last_use_path(), f"{time.time():.6f}\n")
+    except OSError:
+        pass  # a missing timestamp only means the model stays loaded longer
+
+
+def idle_stop(sleep_idle_seconds) -> bool:
+    """Stop a resident server that has been idle past its deadline.
+
+    llama-server has no native idle timeout and this tool deliberately keeps
+    no daemon of its own, so staleness can only be discovered lazily: the next
+    invocation compares the wall clock against the last-use timestamp and
+    SIGTERMs the server via stop_server() before starting a fresh one. The
+    practical consequence: the model stays resident until the first query that
+    arrives AFTER the deadline, not unloaded at exactly N seconds. That trade
+    buys zero background processes and no new failure modes.
+
+    Returns True when a stale server was actually stopped.
+    """
+    if not sleep_idle_seconds or sleep_idle_seconds <= 0:
+        return False
+    sd = _state_dir()
+    p = _last_use_path()
+    if not (sd / "server.pid").exists() or not p.exists():
+        return False
+    try:
+        last = float(p.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    if time.time() - last < sleep_idle_seconds:
+        return False
+    return stop_server()
+
+
 def start_server(model: Path, server_bin: Path, threads: int,
                  wait: float = 180.0, quiet: bool = False,
                  port: int | None = None, ctx_size: int = 2048) -> int:
@@ -1024,10 +1071,16 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
 
     t0 = time.time()
     if server_bin is not None:
+        # Lazy idle unload: before the reuse check inside start_server(), drop
+        # a resident server that has been idle past --sleep-idle-seconds.
+        # stop_server() clears pid/params/socket, so start_server() below sees
+        # no live server and launches a fresh one.
+        idle_stop(cfg.get("sleep_idle_seconds", 0))
         port = start_server(model, server_bin, threads, quiet=quiet,
                             port=cfg.get("server_port"),
                             ctx_size=cfg.get("ctx_size", 2048))
         raws = _query_server(port, user_msg, cfg, n, system=system, grammar=grammar)
+        touch_last_use(cfg.get("sleep_idle_seconds", 0))
         mode = "server"
     else:
         cli = cfg_mod.find_llama_cli()


### PR DESCRIPTION
## What does this change do, and why?

This implements #42: an option for the model to unload itself after it hasn't been used for a while. The resident `llama-server` keeps the ~1 GB model in RAM between queries, which is what makes answers feel instant, but on a shared or memory-constrained box that RAM is wasted once you stop using the tool — and today the only way to get it back is `whatisit stop`, which also throws away the fast path entirely.

One thing worth flagging up front: **llama-server has no native idle timeout**, and whatisit deliberately keeps no daemon of its own, so the model can't literally unload itself at exactly N seconds. This PR implements the pragmatic version:

- New config key `sleep_idle_seconds` (default `0` = off, so nothing changes unless you ask). Each successful server-mode query records a timestamp in `<state>/server.last_use` (0600, same `_write_private` treatment as the pid/token files).
- On the next invocation, if a resident server exists and `now - last_use >= N`, it is SIGTERMed through the existing `stop_server()` *before* `start_server()`'s reuse check runs, so the query then starts fresh.
- The trade-off (stated in the README too): the model stays resident until the first query arriving *after* the deadline, not unloaded at exactly N seconds. That buys zero background processes and no new failure modes.
- Remote mode and `--oneshot` are untouched; the key is deliberately **not** part of `start_server()`'s `requested` params since it doesn't affect the server command line — changing it shouldn't force a restart.

Per-invocation flag follows the existing value-flag pattern (`--port`/`--threads`/`--ctx-size`) in both argparse and the hand parser:

```bash
whatisit --sleep-idle-seconds 300 show disk usage
whatisit config --set sleep_idle_seconds=300   # persist it
```

## How I tested it

Real machine test (resident server, installed runtime):

```
$ whatisit --sleep-idle-seconds 2 -q show current directory
pwd
# server.last_use written, server running as pid 5093

$ sleep 4 && whatisit --sleep-idle-seconds 2 -q show current directory
pwd
# pid 5093 gone, fresh server started as pid 5147
```

Suite: 361 passed, coverage 82% (CI gate 58%), ruff clean. 19 new hermetic tests cover the idle check firing only when stale + running pid, missing/corrupt timestamps being ignored rather than fatal, ordering through `generate()` (idle check before reuse), and the CLI parse/validate/override paths.

## Notes for review

- One pre-existing failure (`TestCmdQueryQuietDangerRefusal::test_execute_marks_generation_as_execution_intended`) fails on pristine master too — that test class doesn't isolate `WHATISIT_CONFIG_DIR`, so a real user config with `confirm_execute=false` leaks in and the test currently executes a real command instead of refusing at the no-tty gate. Unrelated to this PR but worth a look separately; same one PR #41 saw.
- Commits are split by layer (engine / cli / docs) like #41; happy to squash if you'd rather have one.

Closes #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional distro-aware package-manager guidance for generated install commands.
  - Added `--distro-guidance` and `--no-distro-guidance` controls.
  - Added configurable idle timeouts for automatically stopping resident model servers.
  - Added persistent and per-invocation configuration examples.

- **Bug Fixes**
  - Improved package-name handling, including DNF names containing underscores and digits.
  - Extended package-aware behavior across local and remote generation.

- **Documentation**
  - Documented package-manager guidance, idle shutdown behavior, and backend-specific configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->