### PR TITLE
Community models: greeting-input fix for #10 (+6.7 pts InterCode-ALFA), Qwen3.5-2B variant in training

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,23 @@ it came from a command this model actually produced during testing, which means
 it covers the mistakes I've seen and not the ones I haven't. Read the command
 before you run it.
 
+## Community models
+
+Third-party fine-tunes that follow this project's benchmark protocol:
+
+| model | size | InterCode-ALFA | notes |
+|---|---|---|---|
+| [nl2sh-qwen25-coder-1.5b](https://huggingface.co/barbarabhb/nl2sh-qwen25-coder-1.5b-GGUF) | 941 MB (Q4_K_M) | 0.657 | trained with organic greeting/chatter data — addresses the `hello` → network-command behavior reported in #10 |
+
+Same base family as the default model, LoRA recipe close to the one above
+(32/64, all-linear, 2e-4 cosine), but on a broadened data pool: NL2SH-ALFA
+train split + tldr-pages + commandlinefu + NL2Bash + cli-1m sample +
+git-instruction. Examples are length-capped to 56 tokens, deduplicated, and
+decontaminated against this repo's test set.
+
+A Qwen3.5-2B hybrid-architecture variant is currently in training and will be
+added when its numbers are in.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
Hi! I've been reproducing and extending the training setup, and along the way ended up fixing exactly what #10 describes — so I wanted to share it back.

## The #10 problem

Typing `hello` or `hi` produced things like:

```
echo $(curl -s https://api.random.org/json/ | jq '.data[0].result[0]' -r)
  ! caution contacts the network
```

A network-touching command for a greeting. My own fine-tune had the same failure mode, so instead of post-filtering I fixed it where the issue label says it belongs: the training data. Added ~250 organic chatter pairs (greetings, thanks, gibberish, ambiguous requests) mapped to harmless commands. Behavior now:

```
> hello   → echo hello
> hi      → echo hello
> who am i → whoami
> qwerty  → pwd
```

## Benchmark results

InterCode-ALFA, 300 tasks, temp 0, max_tokens 64, unmodified upstream scorer with embedding heuristic at threshold 0.75:

| model | size | pass rate |
|---|---|---|
| GPT-4o (published) | cloud | 0.730 |
| **nl2sh-qwen25-coder-1.5b Q4_K_M (this PR's model)** | **941 MB** | **0.657** |
| nl2sh-3b (published) | 1.9G | 0.657 |
| nl2sh-1.5b (published) | 941M | 0.620 |
| nl2sh-1.5b (re-measured on my rig, same protocol) | 941M | 0.590 |

Same-size Q4_K_M vs the default model: +3.7 points over the published number, +6.7 head-to-head on identical hardware. Quant-to-quant differences across Q8/Q6/Q4 are within binomial noise at n=300, so read all variants as one ~0.65 blob.

## What's in the training mix

Same LoRA shape as upstream (32/64, all-linear, 2e-4 cosine), but on a broadened pool (~120k pairs): NL2SH-ALFA train split, tldr-pages, commandlinefu, NL2Bash, cli-1m sample, git-instruction, plus the robustness pairs above. Everything length-capped to ≤56 tokens (so answers never hit the 64-token ceiling mid-command), deduplicated, and decontaminated against this repo's test set.

GGUF ladder (Q8/Q6/Q4/Q4-imatrix), f16 reference, and the LoRA adapter are up at:
https://huggingface.co/barbarabhb/nl2sh-qwen25-coder-1.5b-GGUF

Also: a Qwen3.5-2B hybrid-architecture variant is in training right now — will publish numbers when it lands.

## About this PR

The actual change here is small on purpose: just a README section pointing readers who hit #10 at an immediately usable alternative. If you'd rather take the greeting/chatter data approach into the official training pipeline instead (or want the dataset itself), happy to contribute that — just say the word.

Marking as draft since it's really more of a "here's a thing that works" than a merge candidate.
