### PR TITLE
Mention remote endpoints in the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # whatisit-nl2sh
 
-Ask for a shell command in plain English. Runs on your own machine by default,
-on CPU. No GPU, no API key, no network. Answers in about a second.
+Ask for a shell command in plain English. Runs on your own machine on CPU, no
+GPU and no network. Answers in about a second. Optionally any OpenAI-compatible
+endpoint instead.
 
 ![whatisit in use](whatisit.gif)
 

--- a/whatisit_pkg/pyproject.toml
+++ b/whatisit_pkg/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "whatisit"
 version = "0.3.0"
-description = "Natural language to shell command. Runs on your own machine by default, on CPU. No GPU, no API key, no network."
+description = "Natural language to shell command. Runs on your own machine on CPU, no GPU and no network; optionally any OpenAI-compatible endpoint."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
The blurb said "no network" while remote endpoints have been in since #24. Says it plainly now, and the README opening matches.

No version bump, so this rides along with whatever ships next.
