### PR TITLE
feat(sessions,cli,engine): opt-in memory for follow-up requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,34 @@ whatisit -e remove every .pyc file under this tree
 `whatisit stop` shuts down the resident model server. `whatisit config --set threads=4`
 changes settings.
 
+## Follow-up requests (sessions)
+
+By default every request is independent. Opt in with `--session` (or
+`whatisit config --set sessions=true`) and a follow-up that refers back to the
+previous request gets the context it needs:
+
+```bash
+whatisit --session list the python files in this folder
+find . -maxdepth 1 -name "*.py" | head -3
+
+whatisit --session delete them
+rm -f ./*.py
+```
+
+Details worth knowing:
+
+- History is injected **only when the request actually refers back** to
+  something ("them", "those", "run it again"). Ordinary requests get exactly
+  the same prompt as before, and `-q` output is always context-free so
+  scripting stays deterministic.
+- A session expires after 15 minutes of silence or when you change directory.
+- Commands flagged `DANGER` are never stored, so history cannot be used to
+  replay a dangerous command past the safety checker on a later "do it again".
+- Requests are kept on local disk only (`~/.local/share/whatisit/
+  session.jsonl`, owner-readable), at most three turns.
+- `whatisit session show` prints what is remembered; `whatisit session clear`
+  wipes it.
+
 ## Remote endpoints
 
 To use a hosted API, Ollama, or a `llama.cpp` server you already have running:
@@ -248,7 +276,8 @@ slot and, in brackets, the file that slot actually points at.
 This is still in development and will get things wrong. It assumes you know
 your way around a terminal well enough to spot a bad command and fix it.
 
-- Single-turn. No memory of your last command, no shell state.
+- Follow-ups need `--session` (off by default, see above), and even then the
+  1.5B may misresolve an ambiguous "them". No shell state is ever tracked.
 - Output caps at 64 tokens. That's a command, not a script.
 - English only, and measured on one 300-task benchmark, which is not the same
   as being good at shell.

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ Details worth knowing:
 - A session expires after 15 minutes of silence or when you change directory.
 - Commands flagged `DANGER` are never stored, so history cannot be used to
   replay a dangerous command past the safety checker on a later "do it again".
-- Requests are kept on local disk only (`~/.local/share/whatisit/
-  session.jsonl`, owner-readable), at most three turns.
+- Requests are kept on local disk only, at most three turns: `session.jsonl`
+  inside your whatisit data directory (`~/.local/share/whatisit/` by default,
+  owner-readable), the same place `queries.jsonl` lives.
 - `whatisit session show` prints what is remembered; `whatisit session clear`
   wipes it.
 

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -577,7 +577,13 @@ class TestSessionMemory:
         stale = time.time() - sessions_mod.TTL_SECONDS - 1
         turn = {"ts": stale, "cwd": os.getcwd(), "nl": "old request",
                 "command": "old-cmd", "executed": False, "exit_code": None}
-        (data / "session.jsonl").write_text(json.dumps(turn) + "\n")
+        seed = data / "session.jsonl"
+        seed.write_text(json.dumps(turn) + "\n")
+        # Seed at 0600 or the permission rule resets the file before the
+        # stale timestamp is ever consulted -- this test pins the TTL rule,
+        # not the perms rule (which has its own tests).
+        if os.name != "nt":
+            os.chmod(seed, 0o600)
         captured = {}
         self._fake_generate(monkeypatch, captured, ["rm one.py"])
         cli.main(["--session", "delete", "them"])
@@ -613,6 +619,43 @@ class TestSessionMemory:
         turns = [json.loads(line) for line in lines]
         assert turns[-1]["executed"] is True
         assert turns[-1]["exit_code"] == 5
+
+    def test_danger_top_candidate_never_rewrites_the_previous_turn(
+            self, monkeypatch, tmp_path):
+        # Regression: with -n 2 whose greedy candidate is DANGER, nothing is
+        # recorded for this run -- so executing the safe alternative must
+        # NOT rewrite turns[-1], which still belongs to the prior invocation.
+        self._isolate(monkeypatch, tmp_path)
+        cfg_dir = tmp_path / "cfg"
+        cfg_dir.mkdir(parents=True)
+        (cfg_dir / "config.json").write_text('{"confirm_execute": false}')
+        monkeypatch.setattr(cli, "_is_windows", lambda: False)
+
+        class _R:
+            returncode = 0
+
+        monkeypatch.setattr(cli.subprocess, "run", lambda *a, **k: _R())
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["ls *.py"])
+        cli.main(["--session", "list", "python", "files"])
+
+        # This run: candidate 1 flagged DANGER ("rm -rf /" is a critical
+        # path), candidate 2 executable.
+        def fake_generate2(prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                           for_execution=False, extra_context=None):
+            captured["prompt"] = prompt
+            return (["rm -rf /", "rm ./tmp.log"], 0.01, "server")
+        monkeypatch.setattr(cli.engine, "generate", fake_generate2)
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda *a: "2")
+        rc = cli.main(["--session", "-e", "clean", "this", "up"])
+        assert rc == 0
+        lines = self._session_file(tmp_path).read_text().splitlines()
+        turns = [json.loads(line) for line in lines]
+        assert len(turns) == 1
+        assert turns[0]["nl"] == "list python files"
+        assert turns[0]["command"] == "ls *.py"
+        assert turns[0]["executed"] is False
 
     def test_session_subcommand_show_and_clear(self, monkeypatch, tmp_path,
                                                capsys):

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -11,11 +11,14 @@ These cover cases that were REAL bugs found by typing realistic requests:
 None of this starts a server or touches the network: engine.generate is
 monkeypatched wherever cmd_query would otherwise call into it.
 """
+import json
 import os
+import time
 
 import pytest
 
 from whatisit import cli
+from whatisit import sessions as sessions_mod
 
 # ------------------------------------------------------------------ QueryArgs
 
@@ -98,7 +101,7 @@ class TestSubcommandRoutingIsFirstTokenOnly:
         captured = {}
 
         def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
-                          for_execution=False):
+                          for_execution=False, extra_context=None):
             captured["prompt"] = prompt
             return (["git config --list"], 0.01, "server")
 
@@ -107,8 +110,8 @@ class TestSubcommandRoutingIsFirstTokenOnly:
         assert rc == 0
         assert captured["prompt"] == "show me the git config"
 
-    def test_setup_doctor_stop_are_recognized_subcommands(self):
-        assert cli.SUBCOMMANDS == {"setup", "doctor", "stop", "config"}
+    def test_setup_doctor_stop_session_config_are_recognized_subcommands(self):
+        assert cli.SUBCOMMANDS == {"setup", "doctor", "stop", "session", "config"}
 
 
 # --------------------------------------------------------------- cmd_query
@@ -118,7 +121,8 @@ class TestCmdQueryQuietDangerRefusal:
         """`eval "$(whatisit -q ...)"` runs whatever lands on stdout."""
         monkeypatch.setattr(
             cli.engine, "generate",
-            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False, for_execution=False:
+            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                    for_execution=False, extra_context=None:
                 (["chmod 777 ./build"], 0.01, "server"))
         rc = cli.main(["-q", "fix", "permissions"])
         cap = capsys.readouterr()
@@ -129,7 +133,8 @@ class TestCmdQueryQuietDangerRefusal:
     def test_quiet_refuses_danger_command_exit_6(self, monkeypatch, capsys):
         monkeypatch.setattr(
             cli.engine, "generate",
-            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False, for_execution=False:
+            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                    for_execution=False, extra_context=None:
                 (["rm -rf /"], 0.01, "server"))
         rc = cli.main(["-q", "delete", "everything"])
         assert rc == 6
@@ -142,7 +147,7 @@ class TestCmdQueryQuietDangerRefusal:
         captured = {}
 
         def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
-                          for_execution=False):
+                          for_execution=False, extra_context=None):
             captured["for_execution"] = for_execution
             return (["ls -la"], 0.01, "server")
 
@@ -153,11 +158,17 @@ class TestCmdQueryQuietDangerRefusal:
         out = capsys.readouterr()
         assert out.out.strip() == "ls -la"
 
-    def test_execute_marks_generation_as_execution_intended(self, monkeypatch):
+    def test_execute_marks_generation_as_execution_intended(
+            self, monkeypatch, tmp_path):
+        # Isolate config too: an ambient confirm_execute=false on a dev box
+        # would skip the refusal this test exists to pin (latent, pre-dating
+        # sessions -- surfaced here).
+        monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
         captured = {}
 
         def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
-                          for_execution=False):
+                          for_execution=False, extra_context=None):
             captured["for_execution"] = for_execution
             return (["ls -la"], 0.01, "server")
 
@@ -171,7 +182,7 @@ class TestCmdQueryQuietDangerRefusal:
 
     def test_no_model_found_reports_and_exits_3(self, monkeypatch):
         def raise_not_found(prompt, cfg, n=1, force_oneshot=False, quiet=False,
-                            for_execution=False):
+                            for_execution=False, extra_context=None):
             raise FileNotFoundError("no model found -- run `whatisit setup`")
         monkeypatch.setattr(cli.engine, "generate", raise_not_found)
         rc = cli.main(["do", "something"])
@@ -187,7 +198,8 @@ class TestCmdQueryQuietDangerRefusal:
         monkeypatch.setattr(cli, "_is_windows", lambda: True)
         monkeypatch.setattr(
             cli.engine, "generate",
-            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False, for_execution=False:
+            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                    for_execution=False, extra_context=None:
                 (["ls -la"], 0.01, "server"))
         rc = cli.main(["-e", "list", "files"])
         assert rc == 7
@@ -199,7 +211,8 @@ class TestCmdQueryQuietDangerRefusal:
         monkeypatch.setattr(cli, "_is_windows", lambda: False)
         monkeypatch.setattr(
             cli.engine, "generate",
-            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False, for_execution=False:
+            lambda prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                    for_execution=False, extra_context=None:
                 (["ls -la"], 0.01, "server"))
         rc = cli.main(["-e", "list", "files"])
         assert rc != 7
@@ -298,7 +311,7 @@ class TestRemoteCli:
         monkeypatch.setenv("WHATISIT_OPENAI_MODEL", "m")
 
         def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
-                          for_execution=False):
+                          for_execution=False, extra_context=None):
             return (["ls"], 0.01, "remote")
 
         monkeypatch.setattr(cli.engine, "generate", fake_generate)
@@ -399,7 +412,7 @@ class TestQueryFlagsApply:
         self._isolate(monkeypatch, tmp_path)
         seen = {}
         def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
-                          for_execution=False):
+                          for_execution=False, extra_context=None):
             seen["cfg"] = dict(cfg)
             return (["ls -la"], 0.01, "server")
         monkeypatch.setattr(cli.engine, "generate", fake_generate)
@@ -414,7 +427,7 @@ class TestQueryFlagsApply:
         self._isolate(monkeypatch, tmp_path)
         seen = {}
         def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
-                          for_execution=False):
+                          for_execution=False, extra_context=None):
             seen["cfg"] = dict(cfg)
             return (["ls"], 0.01, "server")
         monkeypatch.setattr(cli.engine, "generate", fake_generate)
@@ -428,7 +441,8 @@ class TestQueryFlagsApply:
         monkeypatch.setattr(cli.engine, "generate",
                             lambda *a, **k: (["ls"], 0.01, "server"))
         monkeypatch.setattr(cli.engine.hostctx, "build",
-                            lambda p, enabled=True, cwd=None: ("SYS", p))
+                            lambda p, enabled=True, cwd=None, include_volatile=True,
+                            extra_context=None: ("SYS", p))
         rc = cli.main(["--debug", "list", "files"])
         assert rc == 0
         err = capsys.readouterr().err
@@ -442,7 +456,8 @@ class TestQueryFlagsApply:
         monkeypatch.setattr(cli.engine, "generate",
                             lambda *a, **k: (["ls"], 0.01, "server"))
         monkeypatch.setattr(cli.engine.hostctx, "build",
-                            lambda p, enabled=True, cwd=None: ("SYS", p))
+                            lambda p, enabled=True, cwd=None, include_volatile=True,
+                            extra_context=None: ("SYS", p))
         monkeypatch.setattr(cli.engine.hostctx, "stable_facts",
                             lambda *a, **k: {"pkg": "pacman"})
         # grammar_for_pkg may not exist (PR A vs PR B); if so, create a stub
@@ -456,3 +471,165 @@ class TestQueryFlagsApply:
         assert "--debug" in err
         assert "grammar-blob" in err
         assert "list files" in err
+
+
+# ---------------------------------------------------------- session memory
+
+class TestSessionMemory:
+    """Opt-in cross-invocation memory (sessions.py). Default OFF: every test
+    here either passes --session or pre-sets config sessions=true."""
+
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+
+    @staticmethod
+    def _fake_generate(monkeypatch, captured, cmds):
+        def fake_generate(prompt, cfg, n=1, force_oneshot=False, quiet=False,
+                          for_execution=False, extra_context=None):
+            captured["prompt"] = prompt
+            captured["extra_context"] = extra_context
+            return (cmds, 0.01, "server")
+        monkeypatch.setattr(cli.engine, "generate", fake_generate)
+
+    def _session_file(self, tmp_path):
+        return tmp_path / "data" / "session.jsonl"
+
+    def test_session_flag_parses_before_the_request(self):
+        a = cli.QueryArgs(["--session", "find", "logs"])
+        assert a.session is True
+        assert a.words == ["find", "logs"]
+
+    def test_off_by_default_records_nothing(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["ls"])
+        rc = cli.main(["execute", "them"])
+        assert rc == 0
+        assert not self._session_file(tmp_path).exists()
+        assert captured["extra_context"] is None
+
+    def test_followup_injects_prior_turn(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["ls *.py | head -3"])
+        cli.main(["--session", "list", "three", "python", "files", "here"])
+        self._fake_generate(monkeypatch, captured, ["rm one.py"])
+        rc = cli.main(["--session", "delete", "them"])
+        assert rc == 0
+        assert captured["extra_context"] == (
+            'Prior: "list three python files here" -> ls *.py | head -3')
+
+    def test_non_anaphoric_gets_no_context_but_still_records(
+            self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["ls -la"])
+        cli.main(["--session", "list", "files", "in", "this", "folder"])
+        assert captured["extra_context"] is None
+        lines = self._session_file(tmp_path).read_text().splitlines()
+        assert len(lines) == 1
+
+    def test_quiet_never_receives_context_but_records(
+            self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["ls *.py"])
+        cli.main(["--session", "list", "python", "files"])
+        self._fake_generate(monkeypatch, captured, ["rm one.py"])
+        rc = cli.main(["--session", "-q", "execute", "them"])
+        assert rc == 0
+        assert captured["extra_context"] is None
+        assert len(self._session_file(tmp_path).read_text().splitlines()) == 2
+
+    def test_enabled_via_config_not_flag(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        cfg_dir = tmp_path / "cfg"
+        cfg_dir.mkdir(parents=True)
+        (cfg_dir / "config.json").write_text('{"sessions": true}')
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["ls"])
+        cli.main(["list", "python", "files"])
+        assert self._session_file(tmp_path).exists()
+
+    def test_danger_command_is_never_recorded(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["rm -rf /"])
+        rc = cli.main(["--session", "delete", "them"])
+        assert rc == 0
+        assert not self._session_file(tmp_path).exists()
+
+    def test_caution_command_is_recorded(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["chmod 777 ./build"])
+        rc = cli.main(["--session", "open", "permissions", "on", "it"])
+        assert rc == 0
+        lines = self._session_file(tmp_path).read_text().splitlines()
+        turns = [json.loads(line) for line in lines]
+        assert turns[-1]["command"] == "chmod 777 ./build"
+
+    def test_stale_session_is_reset_before_injection(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        data = tmp_path / "data"
+        data.mkdir(parents=True)
+        stale = time.time() - sessions_mod.TTL_SECONDS - 1
+        turn = {"ts": stale, "cwd": os.getcwd(), "nl": "old request",
+                "command": "old-cmd", "executed": False, "exit_code": None}
+        (data / "session.jsonl").write_text(json.dumps(turn) + "\n")
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["rm one.py"])
+        cli.main(["--session", "delete", "them"])
+        # Expired history must not reach the prompt. The file exists again
+        # afterwards: this very run recorded a fresh turn over the reset.
+        assert captured["extra_context"] is None
+        lines = self._session_file(tmp_path).read_text().splitlines()
+        turns = [json.loads(line) for line in lines]
+        assert [t["nl"] for t in turns] == ["delete them"]
+        assert all(t["ts"] > time.time() - 60 for t in turns)
+
+    def test_execute_overwrites_with_actual_command_and_rc(
+            self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        cfg_dir = tmp_path / "cfg"
+        cfg_dir.mkdir(parents=True)
+        (cfg_dir / "config.json").write_text('{"confirm_execute": false}')
+
+        class _R:
+            returncode = 5
+
+        monkeypatch.setattr(cli, "_is_windows", lambda: False)
+
+        def fake_run(*a, **k):
+            return _R()
+
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["ls -la"])
+        rc = cli.main(["--session", "-e", "-y", "list", "files"])
+        assert rc == 5
+        lines = self._session_file(tmp_path).read_text().splitlines()
+        turns = [json.loads(line) for line in lines]
+        assert turns[-1]["executed"] is True
+        assert turns[-1]["exit_code"] == 5
+
+    def test_session_subcommand_show_and_clear(self, monkeypatch, tmp_path,
+                                               capsys):
+        self._isolate(monkeypatch, tmp_path)
+        assert cli.main(["session", "show"]) == 0
+        assert "no session stored" in capsys.readouterr().out
+        captured = {}
+        self._fake_generate(monkeypatch, captured, ["ls"])
+        cli.main(["--session", "list", "files"])
+        capsys.readouterr()
+        assert cli.main(["session", "show"]) == 0
+        out = capsys.readouterr().out
+        assert "list files" in out and "ls" in out
+        assert cli.main(["session", "clear"]) == 0
+        assert "cleared" in capsys.readouterr().out
+        assert not self._session_file(tmp_path).exists()
+
+    def test_request_containing_session_word_midway_is_a_query(self):
+        a = cli.QueryArgs(["show", "my", "session", "history"])
+        assert a.words[0] == "show"

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -595,8 +595,10 @@ class TestGenerateDiscardsTruncatedCandidates:
 
         class CaptureHostCtx:
             @staticmethod
-            def build(prompt, enabled=True, cwd=None, include_volatile=True):
+            def build(prompt, enabled=True, cwd=None, include_volatile=True,
+                      extra_context=None):
                 captured["include_volatile"] = include_volatile
+                captured["extra_context"] = extra_context
                 return ("SYSTEM PROMPT", prompt)
 
             @staticmethod
@@ -720,7 +722,8 @@ class TestServerOverridesReachTheBoundary:
 
 class _FakeHostCtx:
     @staticmethod
-    def build(prompt, enabled=True, cwd=None, include_volatile=True):
+    def build(prompt, enabled=True, cwd=None, include_volatile=True,
+              extra_context=None):
         return ("SYSTEM PROMPT", prompt)
     @staticmethod
     def stable_facts():
@@ -957,7 +960,8 @@ class TestGenerateRemote:
     def _enable_remote(self, monkeypatch, remote):
         monkeypatch.setattr(cfg_mod, "remote_config", lambda cfg: remote)
         monkeypatch.setattr(engine.hostctx, "build",
-                            lambda p, enabled=True, cwd=None, include_volatile=True: ("SYS", p))
+                            lambda p, enabled=True, cwd=None, include_volatile=True,
+                    extra_context=None: ("SYS", p))
 
     @pytest.mark.parametrize("kwargs", [{"quiet": True}, {"for_execution": True}])
     def test_remote_execution_paths_suppress_volatile_host_context(
@@ -966,8 +970,10 @@ class TestGenerateRemote:
         monkeypatch.setattr(cfg_mod, "remote_config", lambda cfg: remote)
         captured = {}
 
-        def capture_context(prompt, enabled=True, cwd=None, include_volatile=True):
+        def capture_context(prompt, enabled=True, cwd=None, include_volatile=True,
+                                extra_context=None):
             captured["include_volatile"] = include_volatile
+            captured["extra_context"] = extra_context
             return ("SYS", prompt)
 
         monkeypatch.setattr(engine.hostctx, "build", capture_context)
@@ -1057,7 +1063,8 @@ class TestGenerateGrammarAndPostprocess:
 
         class FakeHost:
             @staticmethod
-            def build(prompt, enabled=True, cwd=None, include_volatile=True):
+            def build(prompt, enabled=True, cwd=None, include_volatile=True,
+                      extra_context=None):
                 return ("SYS", prompt)
             @staticmethod
             def stable_facts():
@@ -1088,7 +1095,8 @@ class TestGenerateGrammarAndPostprocess:
         self._fake_cfg_and_model(monkeypatch, tmp_path)
         # Drive postprocessing with the real implementation, pinned to pacman.
         monkeypatch.setattr(engine.hostctx, "build",
-                            lambda p, enabled=True, cwd=None, include_volatile=True: ("SYS", p))
+                            lambda p, enabled=True, cwd=None, include_volatile=True,
+                    extra_context=None: ("SYS", p))
         monkeypatch.setattr(engine.hostctx, "stable_facts",
                             lambda *a, **k: {"pkg": "pacman"})
         monkeypatch.setattr(engine.hostctx, "grammar_for_pkg",
@@ -1130,3 +1138,104 @@ class TestGenerateGrammarAndPostprocess:
         for flag in ("--file", "--system-prompt-file", "--grammar-file"):
             path = cmd[cmd.index(flag) + 1]
             assert not os.path.exists(path)
+
+
+# ---------------------------------------------- generate(): session context
+
+class TestSessionContextForwarding:
+    """generate() must forward preformatted session history into the user
+    message on every backend path (the gating decision lives in the CLI)."""
+
+    def _fake_cfg_and_model(self, monkeypatch, tmp_path):
+        model = tmp_path / "model.gguf"
+        model.write_bytes(b"fake")
+        monkeypatch.setattr(cfg_mod, "find_model", lambda: model)
+        srv = tmp_path / "llama-server"
+        srv.write_bytes(b"fake")
+        monkeypatch.setenv("WHATISIT_LLAMA_SERVER", str(srv))
+        monkeypatch.setattr(engine, "start_server", lambda *a, **kw: 12345)
+
+    @staticmethod
+    def _capture_hostctx(monkeypatch, captured):
+        class CaptureHostCtx:
+            @staticmethod
+            def build(prompt, enabled=True, cwd=None, include_volatile=True,
+                      extra_context=None):
+                captured["system"] = "SYSTEM PROMPT"
+                captured["user_msg"] = \
+                    (f"[{extra_context}] " if extra_context else "") + prompt
+                return captured["system"], captured["user_msg"]
+
+            @staticmethod
+            def stable_facts():
+                return {"pkg": "unknown"}
+
+            @staticmethod
+            def postprocess_command(cmd, pkg_mgr):
+                return cmd
+
+            @staticmethod
+            def grammar_for_pkg(pkg_mgr):
+                return None
+
+            @staticmethod
+            def is_install_request(prompt):
+                return False
+
+        monkeypatch.setattr(engine, "hostctx", CaptureHostCtx())
+
+    @staticmethod
+    def _capture_query_server(monkeypatch, captured):
+        def fake_query_server(port, prompt, cfg, n, system=None, grammar=None):
+            captured["sent_prompt"] = prompt
+            return [("ls -la", "stop")]
+        monkeypatch.setattr(engine, "_query_server", fake_query_server)
+
+    def test_extra_context_reaches_the_user_message(self, monkeypatch, tmp_path):
+        self._fake_cfg_and_model(monkeypatch, tmp_path)
+        captured = {}
+        self._capture_hostctx(monkeypatch, captured)
+        self._capture_query_server(monkeypatch, captured)
+        engine.generate("delete them", {}, extra_context='Prior: "list py" -> ls')
+        assert 'Prior: "list py" -> ls' in captured["sent_prompt"]
+        assert captured["sent_prompt"].startswith("[Prior:")
+
+    def test_none_extra_context_is_byte_identical(self, monkeypatch, tmp_path):
+        self._fake_cfg_and_model(monkeypatch, tmp_path)
+        captured = {}
+        self._capture_hostctx(monkeypatch, captured)
+        self._capture_query_server(monkeypatch, captured)
+        engine.generate("list files", {})
+        baseline = (captured["system"], captured["sent_prompt"])
+        engine.generate("list files", {}, extra_context=None)
+        assert (captured["system"], captured["sent_prompt"]) == baseline
+
+    def test_remote_backend_receives_it_too(self, monkeypatch):
+        monkeypatch.setattr(cfg_mod, "remote_config",
+                            lambda cfg: {"base_url": "http://h/v1",
+                                         "api_key": "", "model": "m",
+                                         "timeout": 5, "max_tokens": 64})
+        captured = {}
+
+        def fake_remote_post(base, model, api_key, body, timeout=120.0):
+            captured.update(body)
+            return [("ls -la", "stop")]
+
+        monkeypatch.setattr(engine, "_remote_post", fake_remote_post)
+
+        class CaptureHostCtx:
+            @staticmethod
+            def build(prompt, enabled=True, cwd=None, include_volatile=True,
+                      extra_context=None):
+                user = (f"[{extra_context}] " if extra_context else "") + prompt
+                return ("SYSTEM PROMPT", user)
+
+            @staticmethod
+            def stable_facts():
+                return {"pkg": "unknown"}
+
+        monkeypatch.setattr(engine, "hostctx", CaptureHostCtx())
+        engine.generate("delete them", {},
+                        extra_context='Prior: "list py" -> ls')
+        msgs = {m["role"]: m["content"] for m in captured["messages"]}
+        assert "Prior:" in msgs["user"]

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -1162,6 +1162,7 @@ class TestSessionContextForwarding:
             def build(prompt, enabled=True, cwd=None, include_volatile=True,
                       extra_context=None):
                 captured["system"] = "SYSTEM PROMPT"
+                captured["extra_context"] = extra_context
                 captured["user_msg"] = \
                     (f"[{extra_context}] " if extra_context else "") + prompt
                 return captured["system"], captured["user_msg"]
@@ -1201,14 +1202,19 @@ class TestSessionContextForwarding:
         assert captured["sent_prompt"].startswith("[Prior:")
 
     def test_none_extra_context_is_byte_identical(self, monkeypatch, tmp_path):
+        # The forwarding contract lives in generate(): with no history, the
+        # kwarg must arrive as None and the prompt must be the bare request.
         self._fake_cfg_and_model(monkeypatch, tmp_path)
         captured = {}
         self._capture_hostctx(monkeypatch, captured)
         self._capture_query_server(monkeypatch, captured)
         engine.generate("list files", {})
-        baseline = (captured["system"], captured["sent_prompt"])
+        assert captured["extra_context"] is None
+        baseline = captured["sent_prompt"]
+        assert baseline == "list files"
         engine.generate("list files", {}, extra_context=None)
-        assert (captured["system"], captured["sent_prompt"]) == baseline
+        assert captured["extra_context"] is None
+        assert captured["sent_prompt"] == baseline
 
     def test_remote_backend_receives_it_too(self, monkeypatch):
         monkeypatch.setattr(cfg_mod, "remote_config",

--- a/whatisit_pkg/tests/test_hostctx.py
+++ b/whatisit_pkg/tests/test_hostctx.py
@@ -838,6 +838,7 @@ class TestBuildExtraContext:
         monkeypatch.setattr(hostctx, "_git_state", lambda cwd: "")
 
     BLOCK = 'Prior: "list py files" -> ls'
+    WRAPPED = f"<prior_turns>\n{BLOCK}\n</prior_turns>"
 
     def test_none_is_byte_identical_in_all_switch_combos(self, tmp_path):
         for enabled in (False, True):
@@ -852,7 +853,7 @@ class TestBuildExtraContext:
         _, user = hostctx.build("delete them", enabled=True, cwd=tmp_path,
                                 include_volatile=True, extra_context=self.BLOCK)
         vol = hostctx.volatile_block(tmp_path)
-        assert user == (f"{vol}\n\n{self.BLOCK}"
+        assert user == (f"{vol}\n\n{self.WRAPPED}"
                         "\n\n<request>\ndelete them\n</request>")
 
     def test_survives_include_volatile_false(self):
@@ -861,7 +862,7 @@ class TestBuildExtraContext:
         system, user = hostctx.build("delete them", enabled=True,
                                      include_volatile=False,
                                      extra_context=self.BLOCK)
-        assert user == f"{self.BLOCK}\n\ndelete them"
+        assert user == f"{self.WRAPPED}\n\ndelete them"
 
     def test_works_with_host_context_disabled(self):
         # The two features are independently switchable: sessions=true with
@@ -869,4 +870,4 @@ class TestBuildExtraContext:
         system, user = hostctx.build("delete them", enabled=False,
                                      extra_context=self.BLOCK)
         assert system == cfg_mod.SYSTEM_PROMPT
-        assert user == f"{self.BLOCK}\n\ndelete them"
+        assert user == f"{self.WRAPPED}\n\ndelete them"

--- a/whatisit_pkg/tests/test_hostctx.py
+++ b/whatisit_pkg/tests/test_hostctx.py
@@ -820,3 +820,53 @@ class TestPostprocess:
     def test_multi_package_install(self):
         got = hostctx.postprocess_command("apt-get install htop nmon", "pacman")
         assert got == "pacman -S htop nmon"
+
+
+# ------------------------------------------------- build(): session context
+
+class TestBuildExtraContext:
+    """Session history (extra_context) is independent of both host-context
+    switches and must sit immediately before the <request> tag. None must
+    leave every output byte-identical to before the feature existed."""
+
+    FACTS = {"distro": "Ubuntu", "distro_version": "22.04", "arch": "x86_64",
+             "shell": "bash", "pkg": "apt", "present": ["git"], "missing": []}
+
+    @pytest.fixture(autouse=True)
+    def _no_probe(self, monkeypatch):
+        monkeypatch.setattr(hostctx, "stable_facts", lambda: self.FACTS)
+        monkeypatch.setattr(hostctx, "_git_state", lambda cwd: "")
+
+    BLOCK = 'Prior: "list py files" -> ls'
+
+    def test_none_is_byte_identical_in_all_switch_combos(self, tmp_path):
+        for enabled in (False, True):
+            for volatile in (False, True):
+                assert (hostctx.build("do a thing", enabled=enabled,
+                                      cwd=tmp_path, include_volatile=volatile)
+                        == hostctx.build("do a thing", enabled=enabled,
+                                         cwd=tmp_path, include_volatile=volatile,
+                                         extra_context=None))
+
+    def test_sits_between_volatile_block_and_request_tag(self, tmp_path):
+        _, user = hostctx.build("delete them", enabled=True, cwd=tmp_path,
+                                include_volatile=True, extra_context=self.BLOCK)
+        vol = hostctx.volatile_block(tmp_path)
+        assert user == (f"{vol}\n\n{self.BLOCK}"
+                        "\n\n<request>\ndelete them\n</request>")
+
+    def test_survives_include_volatile_false(self):
+        # -e withholds ambient directory facts but must keep history: the
+        # whole point is resolving "them" against the previous turn.
+        system, user = hostctx.build("delete them", enabled=True,
+                                     include_volatile=False,
+                                     extra_context=self.BLOCK)
+        assert user == f"{self.BLOCK}\n\ndelete them"
+
+    def test_works_with_host_context_disabled(self):
+        # The two features are independently switchable: sessions=true with
+        # host_context=false must still inject, on the bare-prompt path.
+        system, user = hostctx.build("delete them", enabled=False,
+                                     extra_context=self.BLOCK)
+        assert system == cfg_mod.SYSTEM_PROMPT
+        assert user == f"{self.BLOCK}\n\ndelete them"

--- a/whatisit_pkg/tests/test_sessions.py
+++ b/whatisit_pkg/tests/test_sessions.py
@@ -1,0 +1,282 @@
+"""Tests for whatisit.sessions: NDJSON turn storage, owner-only file
+discipline, TTL/cwd invalidation, and anaphora detection.
+
+Every test isolates itself via monkeypatch -- none may read or write the real
+~/.local/share, and none may depend on the ambient working directory.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import pytest
+
+from whatisit import sessions
+
+
+@pytest.fixture
+def iso(tmp_path, monkeypatch):
+    """Isolated data dir + working directory. Returns the data dir path."""
+    data = tmp_path / "data"
+    monkeypatch.setenv("WHATISIT_DATA_DIR", str(data))
+    monkeypatch.chdir(tmp_path)
+    return data
+
+
+def _seed(iso, turns):
+    """Write raw NDJSON directly, bypassing record(). Seeded owner-only: a
+    wide-open session file is by definition an invalid one (see load_valid),
+    so tests simulating a legitimate store must match its permissions."""
+    iso.mkdir(parents=True, exist_ok=True)
+    p = iso / "session.jsonl"
+    p.write_text("".join(json.dumps(t) + "\n" for t in turns))
+    if os.name != "nt":
+        os.chmod(p, 0o600)
+    return p
+
+
+def _turn(nl="list files", command="ls", **over):
+    t = {"ts": time.time(), "cwd": os.getcwd(), "nl": nl,
+         "command": command, "executed": False, "exit_code": None}
+    t.update(over)
+    return t
+
+
+# ---------------------------------------------------------------- NDJSON I/O
+
+class TestStorage:
+    def test_record_writes_one_json_object_per_line(self, iso):
+        sessions.record("list files", "ls")
+        sessions.record("show disk usage", "df -h")
+        lines = (iso / "session.jsonl").read_text().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["nl"] == "list files"
+        assert json.loads(lines[1])["command"] == "df -h"
+
+    def test_fourth_turn_drops_the_oldest(self, iso):
+        for i in range(4):
+            sessions.record(f"request {i}", f"cmd {i}")
+        turns = sessions.show()
+        assert [t["nl"] for t in turns] == ["request 1", "request 2", "request 3"]
+
+    def test_corrupt_line_is_skipped_not_fatal(self, iso):
+        p = _seed(iso, [_turn(nl="a")])
+        with open(p, "a") as f:
+            f.write("{this is not json\n")
+            f.write(json.dumps(_turn(nl="b")) + "\n")
+        assert [t["nl"] for t in sessions.show()] == ["a", "b"]
+        # And recording on top of a corrupt line must keep the valid ones.
+        sessions.record("c", "cmd-c")
+        assert [t["nl"] for t in sessions.show()] == ["a", "b", "c"]
+
+    def test_blank_lines_are_ignored(self, iso):
+        p = _seed(iso, [_turn(nl="a")])
+        with open(p, "a") as f:
+            f.write("\n   \n")
+            f.write(json.dumps(_turn(nl="b")) + "\n")
+        assert [t["nl"] for t in sessions.show()] == ["a", "b"]
+
+    def test_tail_read_survives_a_oversized_garbage_prefix(self, iso):
+        p = _seed(iso, [])
+        junk = "x" * (sessions._TAIL_BYTES * 3)
+        p.write_text(junk + "\n" + json.dumps(_turn(nl="kept")) + "\n")
+        # The junk line is far beyond the tail window; whatever fragment of it
+        # is read must parse to nothing, never crash or resurrect itself.
+        assert [t["nl"] for t in sessions.show()] == ["kept"]
+
+    def test_non_dict_or_wrongly_typed_lines_are_skipped(self, iso):
+        p = iso / "session.jsonl"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('["a","list"]\n' + json.dumps(_turn()) + "\n")
+        assert len(sessions.show()) == 1
+
+    def test_missing_file_reads_as_empty(self, iso):
+        assert sessions.show() == []
+        assert sessions.load_valid() == []
+
+    def test_nl_and_command_truncated_before_storage(self, iso):
+        sessions.record("n" * 5000, "c" * 5000)
+        t = sessions.show()[0]
+        assert len(t["nl"]) == sessions.MAX_NL_CHARS
+        assert len(t["command"]) == sessions.MAX_CMD_CHARS
+
+    def test_show_has_no_reset_side_effects(self, iso, monkeypatch):
+        # A stale file survives show() -- it is an audit view. load_valid is
+        # what decides usability.
+        old = time.time() - sessions.TTL_SECONDS - 60
+        p = _seed(iso, [_turn(ts=old)])
+        assert sessions.show()
+        assert p.exists()
+
+
+class TestUpdateExecuted:
+    def test_overwrites_only_the_newest_turn(self, iso):
+        sessions.record("first", "wrong")
+        sessions.record("second", "ls -la")
+        sessions.update_executed("ls -la /tmp", 3)
+        turns = sessions.show()
+        assert turns[0]["command"] == "wrong"
+        assert turns[0]["executed"] is False
+        assert turns[-1]["command"] == "ls -la /tmp"
+        assert turns[-1]["executed"] is True
+        assert turns[-1]["exit_code"] == 3
+
+    def test_noop_on_empty_store(self, iso):
+        sessions.update_executed("anything", 0)
+        assert sessions.show() == []
+
+    def test_exit_code_coerced_to_int(self, iso):
+        sessions.record("x", "y")
+        sessions.update_executed("y", "7")
+        assert sessions.show()[-1]["exit_code"] == 7
+
+
+# ------------------------------------------------------------- permissions
+
+needs_posix = pytest.mark.skipif(os.name == "nt",
+                                 reason="POSIX permission semantics")
+
+
+class TestPermissions:
+    @needs_posix
+    def test_created_owner_only(self, iso):
+        sessions.record("list files", "ls")
+        p = iso / "session.jsonl"
+        assert (p.stat().st_mode & 0o777) == 0o600
+        assert (iso.stat().st_mode & 0o777) == 0o700
+
+    @needs_posix
+    def test_pre_existing_loose_file_is_repaired_on_rewrite(self, iso):
+        p = _seed(iso, [_turn()])
+        os.chmod(p, 0o644)
+        sessions.record("another", "cmd")     # rewrite goes through fchmod
+        assert (p.stat().st_mode & 0o777) == 0o600
+
+    @needs_posix
+    def test_wrong_permissions_reset_the_session(self, iso):
+        p = _seed(iso, [_turn()])
+        os.chmod(p, 0o666)
+        assert sessions.load_valid() == []
+        assert not p.exists()
+
+    @needs_posix
+    def test_planted_symlink_is_never_followed(self, iso, tmp_path):
+        sentinel = tmp_path / "sentinel.txt"
+        sentinel.write_text("do not touch")
+        iso.mkdir(parents=True, exist_ok=True)
+        (iso / "session.jsonl").symlink_to(sentinel)
+        # Must neither raise nor write through the link; last-writer-wins
+        # means silently doing nothing is the correct outcome here.
+        sessions.record("list files", "ls")
+        assert sentinel.read_text() == "do not touch"
+
+
+# ------------------------------------------------------------ TTL and cwd
+
+class TestInvalidation:
+    def test_fresh_turn_is_kept(self, iso):
+        _seed(iso, [_turn()])
+        assert [t["nl"] for t in sessions.load_valid()] == ["list files"]
+
+    def test_ttl_expiry_resets(self, iso):
+        old = time.time() - sessions.TTL_SECONDS - 1
+        p = _seed(iso, [_turn(ts=old)])
+        assert sessions.load_valid() == []
+        assert not p.exists()
+
+    def test_turn_just_inside_ttl_is_kept(self, iso):
+        edge = time.time() - sessions.TTL_SECONDS + 30
+        _seed(iso, [_turn(ts=edge)])
+        assert sessions.load_valid()
+
+    def test_cwd_change_resets(self, iso, tmp_path, monkeypatch):
+        _seed(iso, [_turn()])
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        monkeypatch.chdir(other)
+        p = iso / "session.jsonl"
+        assert sessions.load_valid() == []
+        assert not p.exists()
+
+    @needs_posix
+    def test_cwd_comparison_is_symlink_normalized(self, iso, tmp_path, monkeypatch):
+        # A session recorded through one path to a directory stays valid when
+        # the shell reaches the same directory through another name.
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        monkeypatch.chdir(real)
+        _seed(iso, [{"ts": time.time(), "cwd": str(link), "nl": "a",
+                     "command": "b", "executed": False, "exit_code": None}])
+        assert sessions.load_valid()
+
+    def test_entirely_corrupt_file_resets(self, iso):
+        p = iso / "session.jsonl"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(os.urandom(256))
+        assert sessions.load_valid() == []
+        assert not p.exists()
+
+
+# ----------------------------------------------------------------- anaphora
+
+class TestLooksAnaphoric:
+    @pytest.mark.parametrize("prompt", [
+        "execute them",
+        "delete those",
+        "open these",
+        "run it again",
+        "can you please remove them",
+        "rename that one",
+        "redo the same for logs",
+        "copy this one over",
+        "them again please",
+        "Please Delete Them",
+    ])
+    def test_positives(self, prompt):
+        assert sessions.looks_anaphoric(prompt) is True
+
+    @pytest.mark.parametrize("prompt", [
+        "find files that are bigger than 100MB",
+        "show processes that use the most memory",
+        "list python files in this directory",
+        "what time is it",
+        "install htop",
+        "compress the logs folder into a tarball",
+        "delete temporary files older than a week",
+        "",
+    ])
+    def test_negatives(self, prompt):
+        assert sessions.looks_anaphoric(prompt) is False
+
+
+# ------------------------------------------------------------ block format
+
+class TestHistoryBlock:
+    def test_exact_tight_format(self, iso):
+        block = sessions.history_block([
+            {"nl": "list three python files here", "command": "ls *.py | head -3"}])
+        assert block == 'Prior: "list three python files here" -> ls *.py | head -3'
+
+    def test_multiple_turns_one_line_each(self, iso):
+        block = sessions.history_block([{"nl": "a", "command": "b"},
+                                        {"nl": "c", "command": "d"}])
+        assert block == 'Prior: "a" -> b\nPrior: "c" -> d'
+
+    def test_empty_history_gives_none(self, iso):
+        assert sessions.history_block([]) is None
+
+
+# ------------------------------------------------------------------ clear
+
+class TestClear:
+    def test_clear_removes_and_reports(self, iso):
+        sessions.record("x", "y")
+        assert sessions.clear() is True
+        assert not (iso / "session.jsonl").exists()
+        assert sessions.clear() is False
+
+    def test_clear_when_nothing_stored(self, iso):
+        assert sessions.clear() is False

--- a/whatisit_pkg/tests/test_sessions.py
+++ b/whatisit_pkg/tests/test_sessions.py
@@ -219,6 +219,15 @@ class TestInvalidation:
         assert sessions.load_valid() == []
         assert not p.exists()
 
+    @pytest.mark.parametrize("bad_ts", [None, "not-a-number", [], {}])
+    def test_unparseable_timestamp_resets_instead_of_raising(self, iso, bad_ts):
+        # _read_turns only validates nl/command as strings; a hand-edited or
+        # half-written ts must kill the session, never crash every
+        # session-enabled query until the file is deleted by hand.
+        _seed(iso, [_turn(ts=bad_ts)])
+        assert sessions.load_valid() == []
+        assert not (iso / "session.jsonl").exists()
+
 
 # ----------------------------------------------------------------- anaphora
 

--- a/whatisit_pkg/uv.lock
+++ b/whatisit_pkg/uv.lock
@@ -1,0 +1,605 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "build"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/ec/bf5ae0a7e5ab57abe8aabdd0759c971883895d1a20c49ae99f8146840c3c/build-1.4.4.tar.gz", hash = "sha256:f832ae053061f3fb524af812dc94b8b84bac6880cd587630e3b5d91a6a9c1703", size = 89220, upload-time = "2026-04-22T20:53:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/88/6764e7a109dd84294850741501145da90d13cdeac9d4e614929464a37420/build-1.4.4-py3-none-any.whl", hash = "sha256:8c3f48a6090b39edec1a273d2d57949aaf13723b01e02f9d518396887519f64d", size = 25921, upload-time = "2026-04-22T20:53:43.251Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "importlib-metadata", version = "9.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10.2'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.10.7"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/26/d22c300112504f5f9a9fd2297ce33c35f3d353e4aeb987c8419453b2a7c2/coverage-7.10.7.tar.gz", hash = "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239", size = 827704, upload-time = "2025-09-21T20:03:56.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6c/3a3f7a46888e69d18abe3ccc6fe4cb16cccb1e6a2f99698931dafca489e6/coverage-7.10.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:fc04cc7a3db33664e0c2d10eb8990ff6b3536f6842c9590ae8da4c614b9ed05a", size = 217987, upload-time = "2025-09-21T20:00:57.218Z" },
+    { url = "https://files.pythonhosted.org/packages/03/94/952d30f180b1a916c11a56f5c22d3535e943aa22430e9e3322447e520e1c/coverage-7.10.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e201e015644e207139f7e2351980feb7040e6f4b2c2978892f3e3789d1c125e5", size = 218388, upload-time = "2025-09-21T20:01:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2b/9e0cf8ded1e114bcd8b2fd42792b57f1c4e9e4ea1824cde2af93a67305be/coverage-7.10.7-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:240af60539987ced2c399809bd34f7c78e8abe0736af91c3d7d0e795df633d17", size = 245148, upload-time = "2025-09-21T20:01:01.768Z" },
+    { url = "https://files.pythonhosted.org/packages/19/20/d0384ac06a6f908783d9b6aa6135e41b093971499ec488e47279f5b846e6/coverage-7.10.7-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8421e088bc051361b01c4b3a50fd39a4b9133079a2229978d9d30511fd05231b", size = 246958, upload-time = "2025-09-21T20:01:03.355Z" },
+    { url = "https://files.pythonhosted.org/packages/60/83/5c283cff3d41285f8eab897651585db908a909c572bdc014bcfaf8a8b6ae/coverage-7.10.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6be8ed3039ae7f7ac5ce058c308484787c86e8437e72b30bf5e88b8ea10f3c87", size = 248819, upload-time = "2025-09-21T20:01:04.968Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/02eb98fdc5ff79f423e990d877693e5310ae1eab6cb20ae0b0b9ac45b23b/coverage-7.10.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e28299d9f2e889e6d51b1f043f58d5f997c373cc12e6403b90df95b8b047c13e", size = 245754, upload-time = "2025-09-21T20:01:06.321Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bc/25c83bcf3ad141b32cd7dc45485ef3c01a776ca3aa8ef0a93e77e8b5bc43/coverage-7.10.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c4e16bd7761c5e454f4efd36f345286d6f7c5fa111623c355691e2755cae3b9e", size = 246860, upload-time = "2025-09-21T20:01:07.605Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b7/95574702888b58c0928a6e982038c596f9c34d52c5e5107f1eef729399b5/coverage-7.10.7-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b1c81d0e5e160651879755c9c675b974276f135558cf4ba79fee7b8413a515df", size = 244877, upload-time = "2025-09-21T20:01:08.829Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b6/40095c185f235e085df0e0b158f6bd68cc6e1d80ba6c7721dc81d97ec318/coverage-7.10.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:606cc265adc9aaedcc84f1f064f0e8736bc45814f15a357e30fca7ecc01504e0", size = 245108, upload-time = "2025-09-21T20:01:10.527Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/50/4aea0556da7a4b93ec9168420d170b55e2eb50ae21b25062513d020c6861/coverage-7.10.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:10b24412692df990dbc34f8fb1b6b13d236ace9dfdd68df5b28c2e39cafbba13", size = 245752, upload-time = "2025-09-21T20:01:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/28/ea1a84a60828177ae3b100cb6723838523369a44ec5742313ed7db3da160/coverage-7.10.7-cp310-cp310-win32.whl", hash = "sha256:b51dcd060f18c19290d9b8a9dd1e0181538df2ce0717f562fff6cf74d9fc0b5b", size = 220497, upload-time = "2025-09-21T20:01:13.459Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1a/a81d46bbeb3c3fd97b9602ebaa411e076219a150489bcc2c025f151bd52d/coverage-7.10.7-cp310-cp310-win_amd64.whl", hash = "sha256:3a622ac801b17198020f09af3eaf45666b344a0d69fc2a6ffe2ea83aeef1d807", size = 221392, upload-time = "2025-09-21T20:01:14.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5d/c1a17867b0456f2e9ce2d8d4708a4c3a089947d0bec9c66cdf60c9e7739f/coverage-7.10.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a609f9c93113be646f44c2a0256d6ea375ad047005d7f57a5c15f614dc1b2f59", size = 218102, upload-time = "2025-09-21T20:01:16.089Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f0/514dcf4b4e3698b9a9077f084429681bf3aad2b4a72578f89d7f643eb506/coverage-7.10.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:65646bb0359386e07639c367a22cf9b5bf6304e8630b565d0626e2bdf329227a", size = 218505, upload-time = "2025-09-21T20:01:17.788Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f6/9626b81d17e2a4b25c63ac1b425ff307ecdeef03d67c9a147673ae40dc36/coverage-7.10.7-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5f33166f0dfcce728191f520bd2692914ec70fac2713f6bf3ce59c3deacb4699", size = 248898, upload-time = "2025-09-21T20:01:19.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ef/bd8e719c2f7417ba03239052e099b76ea1130ac0cbb183ee1fcaa58aaff3/coverage-7.10.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:35f5e3f9e455bb17831876048355dca0f758b6df22f49258cb5a91da23ef437d", size = 250831, upload-time = "2025-09-21T20:01:20.817Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b6/bf054de41ec948b151ae2b79a55c107f5760979538f5fb80c195f2517718/coverage-7.10.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4da86b6d62a496e908ac2898243920c7992499c1712ff7c2b6d837cc69d9467e", size = 252937, upload-time = "2025-09-21T20:01:22.171Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e5/3860756aa6f9318227443c6ce4ed7bf9e70bb7f1447a0353f45ac5c7974b/coverage-7.10.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6b8b09c1fad947c84bbbc95eca841350fad9cbfa5a2d7ca88ac9f8d836c92e23", size = 249021, upload-time = "2025-09-21T20:01:23.907Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0f/bd08bd042854f7fd07b45808927ebcce99a7ed0f2f412d11629883517ac2/coverage-7.10.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4376538f36b533b46f8971d3a3e63464f2c7905c9800db97361c43a2b14792ab", size = 250626, upload-time = "2025-09-21T20:01:25.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a7/4777b14de4abcc2e80c6b1d430f5d51eb18ed1d75fca56cbce5f2db9b36e/coverage-7.10.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:121da30abb574f6ce6ae09840dae322bef734480ceafe410117627aa54f76d82", size = 248682, upload-time = "2025-09-21T20:01:27.105Z" },
+    { url = "https://files.pythonhosted.org/packages/34/72/17d082b00b53cd45679bad682fac058b87f011fd8b9fe31d77f5f8d3a4e4/coverage-7.10.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:88127d40df529336a9836870436fc2751c339fbaed3a836d42c93f3e4bd1d0a2", size = 248402, upload-time = "2025-09-21T20:01:28.629Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7a/92367572eb5bdd6a84bfa278cc7e97db192f9f45b28c94a9ca1a921c3577/coverage-7.10.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ba58bbcd1b72f136080c0bccc2400d66cc6115f3f906c499013d065ac33a4b61", size = 249320, upload-time = "2025-09-21T20:01:30.004Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/88/a23cc185f6a805dfc4fdf14a94016835eeb85e22ac3a0e66d5e89acd6462/coverage-7.10.7-cp311-cp311-win32.whl", hash = "sha256:972b9e3a4094b053a4e46832b4bc829fc8a8d347160eb39d03f1690316a99c14", size = 220536, upload-time = "2025-09-21T20:01:32.184Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ef/0b510a399dfca17cec7bc2f05ad8bd78cf55f15c8bc9a73ab20c5c913c2e/coverage-7.10.7-cp311-cp311-win_amd64.whl", hash = "sha256:a7b55a944a7f43892e28ad4bc0561dfd5f0d73e605d1aa5c3c976b52aea121d2", size = 221425, upload-time = "2025-09-21T20:01:33.557Z" },
+    { url = "https://files.pythonhosted.org/packages/51/7f/023657f301a276e4ba1850f82749bc136f5a7e8768060c2e5d9744a22951/coverage-7.10.7-cp311-cp311-win_arm64.whl", hash = "sha256:736f227fb490f03c6488f9b6d45855f8e0fd749c007f9303ad30efab0e73c05a", size = 220103, upload-time = "2025-09-21T20:01:34.929Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e4/eb12450f71b542a53972d19117ea5a5cea1cab3ac9e31b0b5d498df1bd5a/coverage-7.10.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7bb3b9ddb87ef7725056572368040c32775036472d5a033679d1fa6c8dc08417", size = 218290, upload-time = "2025-09-21T20:01:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/37/66/593f9be12fc19fb36711f19a5371af79a718537204d16ea1d36f16bd78d2/coverage-7.10.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:18afb24843cbc175687225cab1138c95d262337f5473512010e46831aa0c2973", size = 218515, upload-time = "2025-09-21T20:01:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/4c49f7ae09cafdacc73fbc30949ffe77359635c168f4e9ff33c9ebb07838/coverage-7.10.7-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:399a0b6347bcd3822be369392932884b8216d0944049ae22925631a9b3d4ba4c", size = 250020, upload-time = "2025-09-21T20:01:39.617Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/90/a64aaacab3b37a17aaedd83e8000142561a29eb262cede42d94a67f7556b/coverage-7.10.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:314f2c326ded3f4b09be11bc282eb2fc861184bc95748ae67b360ac962770be7", size = 252769, upload-time = "2025-09-21T20:01:41.341Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2e/2dda59afd6103b342e096f246ebc5f87a3363b5412609946c120f4e7750d/coverage-7.10.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c41e71c9cfb854789dee6fc51e46743a6d138b1803fab6cb860af43265b42ea6", size = 253901, upload-time = "2025-09-21T20:01:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/dc/8d8119c9051d50f3119bb4a75f29f1e4a6ab9415cd1fa8bf22fcc3fb3b5f/coverage-7.10.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc01f57ca26269c2c706e838f6422e2a8788e41b3e3c65e2f41148212e57cd59", size = 250413, upload-time = "2025-09-21T20:01:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b3/edaff9c5d79ee4d4b6d3fe046f2b1d799850425695b789d491a64225d493/coverage-7.10.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a6442c59a8ac8b85812ce33bc4d05bde3fb22321fa8294e2a5b487c3505f611b", size = 251820, upload-time = "2025-09-21T20:01:45.915Z" },
+    { url = "https://files.pythonhosted.org/packages/11/25/9a0728564bb05863f7e513e5a594fe5ffef091b325437f5430e8cfb0d530/coverage-7.10.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:78a384e49f46b80fb4c901d52d92abe098e78768ed829c673fbb53c498bef73a", size = 249941, upload-time = "2025-09-21T20:01:47.296Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fd/ca2650443bfbef5b0e74373aac4df67b08180d2f184b482c41499668e258/coverage-7.10.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5e1e9802121405ede4b0133aa4340ad8186a1d2526de5b7c3eca519db7bb89fb", size = 249519, upload-time = "2025-09-21T20:01:48.73Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/f692f125fb4299b6f963b0745124998ebb8e73ecdfce4ceceb06a8c6bec5/coverage-7.10.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d41213ea25a86f69efd1575073d34ea11aabe075604ddf3d148ecfec9e1e96a1", size = 251375, upload-time = "2025-09-21T20:01:50.529Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/75/61b9bbd6c7d24d896bfeec57acba78e0f8deac68e6baf2d4804f7aae1f88/coverage-7.10.7-cp312-cp312-win32.whl", hash = "sha256:77eb4c747061a6af8d0f7bdb31f1e108d172762ef579166ec84542f711d90256", size = 220699, upload-time = "2025-09-21T20:01:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f3/3bf7905288b45b075918d372498f1cf845b5b579b723c8fd17168018d5f5/coverage-7.10.7-cp312-cp312-win_amd64.whl", hash = "sha256:f51328ffe987aecf6d09f3cd9d979face89a617eacdaea43e7b3080777f647ba", size = 221512, upload-time = "2025-09-21T20:01:53.481Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/3e32dbe933979d05cf2dac5e697c8599cfe038aaf51223ab901e208d5a62/coverage-7.10.7-cp312-cp312-win_arm64.whl", hash = "sha256:bda5e34f8a75721c96085903c6f2197dc398c20ffd98df33f866a9c8fd95f4bf", size = 220147, upload-time = "2025-09-21T20:01:55.2Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/94/b765c1abcb613d103b64fcf10395f54d69b0ef8be6a0dd9c524384892cc7/coverage-7.10.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:981a651f543f2854abd3b5fcb3263aac581b18209be49863ba575de6edf4c14d", size = 218320, upload-time = "2025-09-21T20:01:56.629Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4f/732fff31c119bb73b35236dd333030f32c4bfe909f445b423e6c7594f9a2/coverage-7.10.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:73ab1601f84dc804f7812dc297e93cd99381162da39c47040a827d4e8dafe63b", size = 218575, upload-time = "2025-09-21T20:01:58.203Z" },
+    { url = "https://files.pythonhosted.org/packages/87/02/ae7e0af4b674be47566707777db1aa375474f02a1d64b9323e5813a6cdd5/coverage-7.10.7-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a8b6f03672aa6734e700bbcd65ff050fd19cddfec4b031cc8cf1c6967de5a68e", size = 249568, upload-time = "2025-09-21T20:01:59.748Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/77/8c6d22bf61921a59bce5471c2f1f7ac30cd4ac50aadde72b8c48d5727902/coverage-7.10.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:10b6ba00ab1132a0ce4428ff68cf50a25efd6840a42cdf4239c9b99aad83be8b", size = 252174, upload-time = "2025-09-21T20:02:01.192Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/20/b6ea4f69bbb52dac0aebd62157ba6a9dddbfe664f5af8122dac296c3ee15/coverage-7.10.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c79124f70465a150e89340de5963f936ee97097d2ef76c869708c4248c63ca49", size = 253447, upload-time = "2025-09-21T20:02:02.701Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/28/4831523ba483a7f90f7b259d2018fef02cb4d5b90bc7c1505d6e5a84883c/coverage-7.10.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:69212fbccdbd5b0e39eac4067e20a4a5256609e209547d86f740d68ad4f04911", size = 249779, upload-time = "2025-09-21T20:02:04.185Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/9f/4331142bc98c10ca6436d2d620c3e165f31e6c58d43479985afce6f3191c/coverage-7.10.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ea7c6c9d0d286d04ed3541747e6597cbe4971f22648b68248f7ddcd329207f0", size = 251604, upload-time = "2025-09-21T20:02:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/60/bda83b96602036b77ecf34e6393a3836365481b69f7ed7079ab85048202b/coverage-7.10.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b9be91986841a75042b3e3243d0b3cb0b2434252b977baaf0cd56e960fe1e46f", size = 249497, upload-time = "2025-09-21T20:02:07.619Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/af/152633ff35b2af63977edd835d8e6430f0caef27d171edf2fc76c270ef31/coverage-7.10.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b281d5eca50189325cfe1f365fafade89b14b4a78d9b40b05ddd1fc7d2a10a9c", size = 249350, upload-time = "2025-09-21T20:02:10.34Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/71/d92105d122bd21cebba877228990e1646d862e34a98bb3374d3fece5a794/coverage-7.10.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:99e4aa63097ab1118e75a848a28e40d68b08a5e19ce587891ab7fd04475e780f", size = 251111, upload-time = "2025-09-21T20:02:12.122Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9e/9fdb08f4bf476c912f0c3ca292e019aab6712c93c9344a1653986c3fd305/coverage-7.10.7-cp313-cp313-win32.whl", hash = "sha256:dc7c389dce432500273eaf48f410b37886be9208b2dd5710aaf7c57fd442c698", size = 220746, upload-time = "2025-09-21T20:02:13.919Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b1/a75fd25df44eab52d1931e89980d1ada46824c7a3210be0d3c88a44aaa99/coverage-7.10.7-cp313-cp313-win_amd64.whl", hash = "sha256:cac0fdca17b036af3881a9d2729a850b76553f3f716ccb0360ad4dbc06b3b843", size = 221541, upload-time = "2025-09-21T20:02:15.57Z" },
+    { url = "https://files.pythonhosted.org/packages/14/3a/d720d7c989562a6e9a14b2c9f5f2876bdb38e9367126d118495b89c99c37/coverage-7.10.7-cp313-cp313-win_arm64.whl", hash = "sha256:4b6f236edf6e2f9ae8fcd1332da4e791c1b6ba0dc16a2dc94590ceccb482e546", size = 220170, upload-time = "2025-09-21T20:02:17.395Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/22/e04514bf2a735d8b0add31d2b4ab636fc02370730787c576bb995390d2d5/coverage-7.10.7-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a0ec07fd264d0745ee396b666d47cef20875f4ff2375d7c4f58235886cc1ef0c", size = 219029, upload-time = "2025-09-21T20:02:18.936Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/91128e099035ece15da3445d9015e4b4153a6059403452d324cbb0a575fa/coverage-7.10.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd5e856ebb7bfb7672b0086846db5afb4567a7b9714b8a0ebafd211ec7ce6a15", size = 219259, upload-time = "2025-09-21T20:02:20.44Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/51/66420081e72801536a091a0c8f8c1f88a5c4bf7b9b1bdc6222c7afe6dc9b/coverage-7.10.7-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f57b2a3c8353d3e04acf75b3fed57ba41f5c0646bbf1d10c7c282291c97936b4", size = 260592, upload-time = "2025-09-21T20:02:22.313Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/22/9b8d458c2881b22df3db5bb3e7369e63d527d986decb6c11a591ba2364f7/coverage-7.10.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1ef2319dd15a0b009667301a3f84452a4dc6fddfd06b0c5c53ea472d3989fbf0", size = 262768, upload-time = "2025-09-21T20:02:24.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/08/16bee2c433e60913c610ea200b276e8eeef084b0d200bdcff69920bd5828/coverage-7.10.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83082a57783239717ceb0ad584de3c69cf581b2a95ed6bf81ea66034f00401c0", size = 264995, upload-time = "2025-09-21T20:02:26.133Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9d/e53eb9771d154859b084b90201e5221bca7674ba449a17c101a5031d4054/coverage-7.10.7-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:50aa94fb1fb9a397eaa19c0d5ec15a5edd03a47bf1a3a6111a16b36e190cff65", size = 259546, upload-time = "2025-09-21T20:02:27.716Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b0/69bc7050f8d4e56a89fb550a1577d5d0d1db2278106f6f626464067b3817/coverage-7.10.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2120043f147bebb41c85b97ac45dd173595ff14f2a584f2963891cbcc3091541", size = 262544, upload-time = "2025-09-21T20:02:29.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/4b/2514b060dbd1bc0aaf23b852c14bb5818f244c664cb16517feff6bb3a5ab/coverage-7.10.7-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:2fafd773231dd0378fdba66d339f84904a8e57a262f583530f4f156ab83863e6", size = 260308, upload-time = "2025-09-21T20:02:31.226Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/7ba2175007c246d75e496f64c06e94122bdb914790a1285d627a918bd271/coverage-7.10.7-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:0b944ee8459f515f28b851728ad224fa2d068f1513ef6b7ff1efafeb2185f999", size = 258920, upload-time = "2025-09-21T20:02:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/fac9f7abbc841409b9a410309d73bfa6cfb2e51c3fada738cb607ce174f8/coverage-7.10.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4b583b97ab2e3efe1b3e75248a9b333bd3f8b0b1b8e5b45578e05e5850dfb2c2", size = 261434, upload-time = "2025-09-21T20:02:34.86Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/51/a03bec00d37faaa891b3ff7387192cef20f01604e5283a5fabc95346befa/coverage-7.10.7-cp313-cp313t-win32.whl", hash = "sha256:2a78cd46550081a7909b3329e2266204d584866e8d97b898cd7fb5ac8d888b1a", size = 221403, upload-time = "2025-09-21T20:02:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/53/22/3cf25d614e64bf6d8e59c7c669b20d6d940bb337bdee5900b9ca41c820bb/coverage-7.10.7-cp313-cp313t-win_amd64.whl", hash = "sha256:33a5e6396ab684cb43dc7befa386258acb2d7fae7f67330ebb85ba4ea27938eb", size = 222469, upload-time = "2025-09-21T20:02:39.011Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a1/00164f6d30d8a01c3c9c48418a7a5be394de5349b421b9ee019f380df2a0/coverage-7.10.7-cp313-cp313t-win_arm64.whl", hash = "sha256:86b0e7308289ddde73d863b7683f596d8d21c7d8664ce1dee061d0bcf3fbb4bb", size = 220731, upload-time = "2025-09-21T20:02:40.939Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9c/5844ab4ca6a4dd97a1850e030a15ec7d292b5c5cb93082979225126e35dd/coverage-7.10.7-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:b06f260b16ead11643a5a9f955bd4b5fd76c1a4c6796aeade8520095b75de520", size = 218302, upload-time = "2025-09-21T20:02:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/89/673f6514b0961d1f0e20ddc242e9342f6da21eaba3489901b565c0689f34/coverage-7.10.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:212f8f2e0612778f09c55dd4872cb1f64a1f2b074393d139278ce902064d5b32", size = 218578, upload-time = "2025-09-21T20:02:44.468Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e8/261cae479e85232828fb17ad536765c88dd818c8470aca690b0ac6feeaa3/coverage-7.10.7-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3445258bcded7d4aa630ab8296dea4d3f15a255588dd535f980c193ab6b95f3f", size = 249629, upload-time = "2025-09-21T20:02:46.503Z" },
+    { url = "https://files.pythonhosted.org/packages/82/62/14ed6546d0207e6eda876434e3e8475a3e9adbe32110ce896c9e0c06bb9a/coverage-7.10.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb45474711ba385c46a0bfe696c695a929ae69ac636cda8f532be9e8c93d720a", size = 252162, upload-time = "2025-09-21T20:02:48.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/49/07f00db9ac6478e4358165a08fb41b469a1b053212e8a00cb02f0d27a05f/coverage-7.10.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:813922f35bd800dca9994c5971883cbc0d291128a5de6b167c7aa697fcf59360", size = 253517, upload-time = "2025-09-21T20:02:50.31Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/59/c5201c62dbf165dfbc91460f6dbbaa85a8b82cfa6131ac45d6c1bfb52deb/coverage-7.10.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:93c1b03552081b2a4423091d6fb3787265b8f86af404cff98d1b5342713bdd69", size = 249632, upload-time = "2025-09-21T20:02:51.971Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ae/5920097195291a51fb00b3a70b9bbd2edbfe3c84876a1762bd1ef1565ebc/coverage-7.10.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:cc87dd1b6eaf0b848eebb1c86469b9f72a1891cb42ac7adcfbce75eadb13dd14", size = 251520, upload-time = "2025-09-21T20:02:53.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/3c/a815dde77a2981f5743a60b63df31cb322c944843e57dbd579326625a413/coverage-7.10.7-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:39508ffda4f343c35f3236fe8d1a6634a51f4581226a1262769d7f970e73bffe", size = 249455, upload-time = "2025-09-21T20:02:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/99/f5cdd8421ea656abefb6c0ce92556709db2265c41e8f9fc6c8ae0f7824c9/coverage-7.10.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:925a1edf3d810537c5a3abe78ec5530160c5f9a26b1f4270b40e62cc79304a1e", size = 249287, upload-time = "2025-09-21T20:02:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/7a/e9a2da6a1fc5d007dd51fca083a663ab930a8c4d149c087732a5dbaa0029/coverage-7.10.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2c8b9a0636f94c43cd3576811e05b89aa9bc2d0a85137affc544ae5cb0e4bfbd", size = 250946, upload-time = "2025-09-21T20:02:59.431Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5b/0b5799aa30380a949005a353715095d6d1da81927d6dbed5def2200a4e25/coverage-7.10.7-cp314-cp314-win32.whl", hash = "sha256:b7b8288eb7cdd268b0304632da8cb0bb93fadcfec2fe5712f7b9cc8f4d487be2", size = 221009, upload-time = "2025-09-21T20:03:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b0/e802fbb6eb746de006490abc9bb554b708918b6774b722bb3a0e6aa1b7de/coverage-7.10.7-cp314-cp314-win_amd64.whl", hash = "sha256:1ca6db7c8807fb9e755d0379ccc39017ce0a84dcd26d14b5a03b78563776f681", size = 221804, upload-time = "2025-09-21T20:03:03.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e8/71d0c8e374e31f39e3389bb0bd19e527d46f00ea8571ec7ec8fd261d8b44/coverage-7.10.7-cp314-cp314-win_arm64.whl", hash = "sha256:097c1591f5af4496226d5783d036bf6fd6cd0cbc132e071b33861de756efb880", size = 220384, upload-time = "2025-09-21T20:03:05.111Z" },
+    { url = "https://files.pythonhosted.org/packages/62/09/9a5608d319fa3eba7a2019addeacb8c746fb50872b57a724c9f79f146969/coverage-7.10.7-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:a62c6ef0d50e6de320c270ff91d9dd0a05e7250cac2a800b7784bae474506e63", size = 219047, upload-time = "2025-09-21T20:03:06.795Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6f/f58d46f33db9f2e3647b2d0764704548c184e6f5e014bef528b7f979ef84/coverage-7.10.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9fa6e4dd51fe15d8738708a973470f67a855ca50002294852e9571cdbd9433f2", size = 219266, upload-time = "2025-09-21T20:03:08.495Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5c/183ffc817ba68e0b443b8c934c8795553eb0c14573813415bd59941ee165/coverage-7.10.7-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8fb190658865565c549b6b4706856d6a7b09302c797eb2cf8e7fe9dabb043f0d", size = 260767, upload-time = "2025-09-21T20:03:10.172Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/48/71a8abe9c1ad7e97548835e3cc1adbf361e743e9d60310c5f75c9e7bf847/coverage-7.10.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:affef7c76a9ef259187ef31599a9260330e0335a3011732c4b9effa01e1cd6e0", size = 262931, upload-time = "2025-09-21T20:03:11.861Z" },
+    { url = "https://files.pythonhosted.org/packages/84/fd/193a8fb132acfc0a901f72020e54be5e48021e1575bb327d8ee1097a28fd/coverage-7.10.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e16e07d85ca0cf8bafe5f5d23a0b850064e8e945d5677492b06bbe6f09cc699", size = 265186, upload-time = "2025-09-21T20:03:13.539Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8f/74ecc30607dd95ad50e3034221113ccb1c6d4e8085cc761134782995daae/coverage-7.10.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03ffc58aacdf65d2a82bbeb1ffe4d01ead4017a21bfd0454983b88ca73af94b9", size = 259470, upload-time = "2025-09-21T20:03:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/55/79ff53a769f20d71b07023ea115c9167c0bb56f281320520cf64c5298a96/coverage-7.10.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1b4fd784344d4e52647fd7857b2af5b3fbe6c239b0b5fa63e94eb67320770e0f", size = 262626, upload-time = "2025-09-21T20:03:17.673Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e2/dac66c140009b61ac3fc13af673a574b00c16efdf04f9b5c740703e953c0/coverage-7.10.7-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0ebbaddb2c19b71912c6f2518e791aa8b9f054985a0769bdb3a53ebbc765c6a1", size = 260386, upload-time = "2025-09-21T20:03:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/f1/f48f645e3f33bb9ca8a496bc4a9671b52f2f353146233ebd7c1df6160440/coverage-7.10.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a2d9a3b260cc1d1dbdb1c582e63ddcf5363426a1a68faa0f5da28d8ee3c722a0", size = 258852, upload-time = "2025-09-21T20:03:21.007Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3b/8442618972c51a7affeead957995cfa8323c0c9bcf8fa5a027421f720ff4/coverage-7.10.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a3cc8638b2480865eaa3926d192e64ce6c51e3d29c849e09d5b4ad95efae5399", size = 261534, upload-time = "2025-09-21T20:03:23.12Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/101f3fa3a45146db0cb03f5b4376e24c0aac818309da23e2de0c75295a91/coverage-7.10.7-cp314-cp314t-win32.whl", hash = "sha256:67f8c5cbcd3deb7a60b3345dffc89a961a484ed0af1f6f73de91705cc6e31235", size = 221784, upload-time = "2025-09-21T20:03:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a1/74c51803fc70a8a40d7346660379e144be772bab4ac7bb6e6b905152345c/coverage-7.10.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e1ed71194ef6dea7ed2d5cb5f7243d4bcd334bfb63e59878519be558078f848d", size = 222905, upload-time = "2025-09-21T20:03:26.93Z" },
+    { url = "https://files.pythonhosted.org/packages/12/65/f116a6d2127df30bcafbceef0302d8a64ba87488bf6f73a6d8eebf060873/coverage-7.10.7-cp314-cp314t-win_arm64.whl", hash = "sha256:7fe650342addd8524ca63d77b2362b02345e5f1a093266787d210c70a50b471a", size = 220922, upload-time = "2025-09-21T20:03:28.672Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/d1c25053764b4c42eb294aae92ab617d2e4f803397f9c7c8295caa77a260/coverage-7.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fff7b9c3f19957020cac546c70025331113d2e61537f6e2441bc7657913de7d3", size = 217978, upload-time = "2025-09-21T20:03:30.362Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/b9f9daa39b80ece0b9548bbb723381e29bc664822d9a12c2135f8922c22b/coverage-7.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bc91b314cef27742da486d6839b677b3f2793dfe52b51bbbb7cf736d5c29281c", size = 218370, upload-time = "2025-09-21T20:03:32.147Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6e/30d006c3b469e58449650642383dddf1c8fb63d44fdf92994bfd46570695/coverage-7.10.7-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:567f5c155eda8df1d3d439d40a45a6a5f029b429b06648235f1e7e51b522b396", size = 244802, upload-time = "2025-09-21T20:03:33.919Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/8a070782ce7e6b94ff6a0b6d7c65ba6bc3091d92a92cef4cd4eb0767965c/coverage-7.10.7-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2af88deffcc8a4d5974cf2d502251bc3b2db8461f0b66d80a449c33757aa9f40", size = 246625, upload-time = "2025-09-21T20:03:36.09Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/92/1c1c5a9e8677ce56d42b97bdaca337b2d4d9ebe703d8c174ede52dbabd5f/coverage-7.10.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7315339eae3b24c2d2fa1ed7d7a38654cba34a13ef19fbcb9425da46d3dc594", size = 248399, upload-time = "2025-09-21T20:03:38.342Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/54/b140edee7257e815de7426d5d9846b58505dffc29795fff2dfb7f8a1c5a0/coverage-7.10.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:912e6ebc7a6e4adfdbb1aec371ad04c68854cd3bf3608b3514e7ff9062931d8a", size = 245142, upload-time = "2025-09-21T20:03:40.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/9e/6d6b8295940b118e8b7083b29226c71f6154f7ff41e9ca431f03de2eac0d/coverage-7.10.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f49a05acd3dfe1ce9715b657e28d138578bc40126760efb962322c56e9ca344b", size = 246284, upload-time = "2025-09-21T20:03:42.355Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e5/5e957ca747d43dbe4d9714358375c7546cb3cb533007b6813fc20fce37ad/coverage-7.10.7-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:cce2109b6219f22ece99db7644b9622f54a4e915dad65660ec435e89a3ea7cc3", size = 244353, upload-time = "2025-09-21T20:03:44.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/45/540fc5cc92536a1b783b7ef99450bd55a4b3af234aae35a18a339973ce30/coverage-7.10.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:f3c887f96407cea3916294046fc7dab611c2552beadbed4ea901cbc6a40cc7a0", size = 244430, upload-time = "2025-09-21T20:03:46.065Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0b/8287b2e5b38c8fe15d7e3398849bb58d382aedc0864ea0fa1820e8630491/coverage-7.10.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:635adb9a4507c9fd2ed65f39693fa31c9a3ee3a8e6dc64df033e8fdf52a7003f", size = 245311, upload-time = "2025-09-21T20:03:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1d/29724999984740f0c86d03e6420b942439bf5bd7f54d4382cae386a9d1e9/coverage-7.10.7-cp39-cp39-win32.whl", hash = "sha256:5a02d5a850e2979b0a014c412573953995174743a3f7fa4ea5a6e9a3c5617431", size = 220500, upload-time = "2025-09-21T20:03:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/43/11/4b1e6b129943f905ca54c339f343877b55b365ae2558806c1be4f7476ed5/coverage-7.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:c134869d5ffe34547d14e174c866fd8fe2254918cc0a95e99052903bc1543e07", size = 221408, upload-time = "2025-09-21T20:03:51.803Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl", hash = "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260", size = 209952, upload-time = "2025-09-21T20:03:53.918Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/c3/4f2195f512fb172aa425a8803a874b2baa9ba7f80ff7b6080998761fc701/coverage-7.15.4.tar.gz", hash = "sha256:0548198fff07ccf4faf469520bce1c2eceb1ce3e62891921138dec10907f9d00", size = 936952, upload-time = "2026-08-06T13:50:24.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/70/b052a519a584663a7bd052841a2debe11c8309ec49a7786340003f9c0a02/coverage-7.15.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d0be6daac4cce6b8c8dc65886bae1b082ddbca4da8e5cbb5e15166acf253e264", size = 222245, upload-time = "2026-08-06T13:46:55.253Z" },
+    { url = "https://files.pythonhosted.org/packages/67/39/892fa511aba3d1c3c8f49509a0ff5c71eab9f9f88d08e1a38da395821660/coverage-7.15.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b24e078eabcd6a9caa8b0713f9bc1eeb310bcc960a29d45a3b4fcd4b16d5b11d", size = 222762, upload-time = "2026-08-06T13:46:57.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/95/b2c724ce1e64bc23cb5b1d7eeffa9548dc3d811f7a6297b2d01607f4e062/coverage-7.15.4-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cfe20cc8cf8821d4fe54f89106cbf06aa27f37b5bbe3535568065a81539b4150", size = 249498, upload-time = "2026-08-06T13:46:59.012Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/4f/b1973f67a1382af65b572a31ed692f8e490a6ad707191eab59148376832a/coverage-7.15.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:83cf06cdd687677742caff1a9134833b7a8b75f111519d2cb0e0ba1b9a851e15", size = 251328, upload-time = "2026-08-06T13:47:00.764Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/09/03efa6722a132abcac91b32a60b64b240dd707c189c64eee697e48992c96/coverage-7.15.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8fa4de68e2a752468ff14b4e15db7def689a71be759e826a31ccecbef69c5fd0", size = 253194, upload-time = "2026-08-06T13:47:01.976Z" },
+    { url = "https://files.pythonhosted.org/packages/45/63/8299201d9c80fb65551ce99c966cab83d706ec4066ac999bef08201346de/coverage-7.15.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4dff9daa47d83120c3ec38ce921214242944a832aa04e903e50b5b7ebac8972d", size = 255106, upload-time = "2026-08-06T13:47:03.281Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/16/26fd8a691eb8d9a230128685f6d23309d7402cb030aa553001788c8c50fc/coverage-7.15.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a093fd37229918976f602aa07aa59e0973cde82186f220c8e197f721f5be0ce4", size = 250177, upload-time = "2026-08-06T13:47:04.713Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ef/3c7556f33783a0a566e01443ca62bd8eb2cdfe22d271efdc02e08beb5654/coverage-7.15.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:317db01a2cb02552fd67e2b1cca77a4b528a2a277176c5e0bf2cecbb639d3f54", size = 251234, upload-time = "2026-08-06T13:47:06.104Z" },
+    { url = "https://files.pythonhosted.org/packages/29/49/640a34043edac950738f36a3567832db5731d4cb2ed84b59cdb89c6bccbf/coverage-7.15.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:8ee3838dcb656602c3b51e16aed9bfb0822f8d8d6d1c5966d32ec8c104be8e20", size = 249237, upload-time = "2026-08-06T13:47:07.467Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f5/e80f212669dd1be954ff844f883ef11a437ef4fd0089c6e0effc7b66b15d/coverage-7.15.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:425920379052ff1fe465268f3361d35804a241bbdd5a1b592c8cb60df4c52325", size = 253050, upload-time = "2026-08-06T13:47:08.748Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/e9/e5da0fe39f7fde1bca9edc09c60921bb5fdba4cec7db5bbad41ddfd8c230/coverage-7.15.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:69bb2400abef928e365ea7d4d9925169ada78ed2295546780002d4b65de3df88", size = 249508, upload-time = "2026-08-06T13:47:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/38/41bf25774a0c8bba6b467f917cb1c9a0a2605e02dc93aad489fc7050ed59/coverage-7.15.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:81661f82d302484e3119e7c80c519c02fa9bcc2a6b339baf67d67bc89c580f04", size = 250110, upload-time = "2026-08-06T13:47:11.35Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/26f2e54b79acc29d179ee4272922625aedb69198c4eb61f7ff4f098f3c78/coverage-7.15.4-cp310-cp310-win32.whl", hash = "sha256:cb476b2e828ecb71cb6b6a928d23fd20a7ddb501188022dae1c37499149cc338", size = 224294, upload-time = "2026-08-06T13:47:12.753Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/06/9a318fc3ae040d4d6cb2d86101c6aa963fab20899a5c58666adf52cde0ca/coverage-7.15.4-cp310-cp310-win_amd64.whl", hash = "sha256:3fc2130bf37df31852a8384f12601563a45a0024bccc6624f38355cba7a8d360", size = 224919, upload-time = "2026-08-06T13:47:14.17Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/edcec7d7a0b524aa8923e22925fde6fe50ce005a113dca13ae1581455c4c/coverage-7.15.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bbac5abad70df71019988f83f26ac7092ff2642975def4429e98dc7585ef3490", size = 222367, upload-time = "2026-08-06T13:47:15.578Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/c6/ab8de429e2e8548faf58ec7e1674a4ce00414b4113942d3fe87109cf0f68/coverage-7.15.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:357a173465c7ce028d07a95cc2b63b5bf59f50ecdd5ad75c5cbb78ada984048e", size = 222874, upload-time = "2026-08-06T13:47:16.961Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c4/3b7b49587e8a6b9af79b3eb468d443d6042b6d65b47aa26586846a0d6566/coverage-7.15.4-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:21b803935e2efc3acebe9697197a294fccf5dc4e5382bd6369542ff7a7d2a1d7", size = 253287, upload-time = "2026-08-06T13:47:18.291Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/65/ec03b743a2a229c72cc1eff3e57be9d3564e9c6b4d5aba2d70744a3fc0d8/coverage-7.15.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7a2b580774a4786c1053157c0165e04476e03ff293993d7c148eee784a94bae6", size = 255199, upload-time = "2026-08-06T13:47:19.765Z" },
+    { url = "https://files.pythonhosted.org/packages/41/4b/5163729e4b6582d61975cfd3ccab45b4ec53e21cf156d9941cb025188468/coverage-7.15.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9464451c4efffe8d47ace5a540b10b0dc10e879066290f8600872b7f54a419d", size = 257308, upload-time = "2026-08-06T13:47:21.206Z" },
+    { url = "https://files.pythonhosted.org/packages/86/08/2167a0f08fb87d702fa423a48578a32865464b7c9e1db3911ad7812ab414/coverage-7.15.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:de602f34123c2f4af1c1869c6dbbbd60da6d5983bf01937367295d135cccbfce", size = 259268, upload-time = "2026-08-06T13:47:22.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e5/68eebae3053dbd48508edea559c21b23fbdf3460784f91370c83a86a6acd/coverage-7.15.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6879ded16a27f3eeca19b900c147e81616e7054db451471a611b2755ee5249f7", size = 253392, upload-time = "2026-08-06T13:47:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/46/fd4ced40a2b691c774e515c9b69500bfa64c7960b67fcee4b2f6fad97fc3/coverage-7.15.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:986be58c3ab54aae8d3496a6225eea74f760fdbe739b38bd442c7e8d133aa53b", size = 255001, upload-time = "2026-08-06T13:47:25.469Z" },
+    { url = "https://files.pythonhosted.org/packages/53/25/ae2e5fa710bb6957a9aadeb9e3598d3b3e4af6587ce857ad42e8639a3f30/coverage-7.15.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c6103639613fe6c1e989082948419bc77a2d26b6c825c99d7fad25f7d3d87afc", size = 253061, upload-time = "2026-08-06T13:47:26.845Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/31/67ddc0365db2c6e93ac8580bc4bbc50f65273262f973f63ebcdbc15c0495/coverage-7.15.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d3af93dddb5659276c63bc16ac6466ac2033a70ca816097bbc06345b8ccdf571", size = 256831, upload-time = "2026-08-06T13:47:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/78/82b8fd18f57fb13f12d98fe874995bb2c4f9f17be8aff762c426323fdb96/coverage-7.15.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:b10075e5421d04265766a6d1dac809bbeb8a946fbb23c8f82c227409b2190719", size = 252781, upload-time = "2026-08-06T13:47:29.712Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/eb/6c74ef4dd12b252e573c49bdef9e2ac265bf3dbb79b8d7feb3266e084e9e/coverage-7.15.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a67a9f78b2942d87ba8ce3059c642164d2aedd65337377fb52fe9803656bc5c7", size = 253692, upload-time = "2026-08-06T13:47:31.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/66/eb9aed1c3fd2d36ee00eb173f434b14fa607fc056739c9a89ff4244010ea/coverage-7.15.4-cp311-cp311-win32.whl", hash = "sha256:69484d1aca26e322e1c3ce03f09341e84524ababad2d7202161738d83cc9f82e", size = 224461, upload-time = "2026-08-06T13:47:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6d/81fa4161dfb3ed9d74e40d58647eff83a56b7612e78352581280fce2f477/coverage-7.15.4-cp311-cp311-win_amd64.whl", hash = "sha256:63fd6fcd1dd6e158f7eb78606e72933b3f6d01e7b747f99c6c12d764307a0fdc", size = 224937, upload-time = "2026-08-06T13:47:34.205Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c1/d8dacf683c6cad3cf85ce68fd3774a6774ec402128822fdfaed920f11e6a/coverage-7.15.4-cp311-cp311-win_arm64.whl", hash = "sha256:ea82116c9893fa89e929b7f197ee5a1950a76e91cc5c85ba503fc02379d04890", size = 224479, upload-time = "2026-08-06T13:47:36.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/48/bc8d4ba7b37551a767bd863f15b3f80182b271c2f55975356f5f7dbe94c2/coverage-7.15.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4fedd1f7f428f9fe83b1ead5e7cc87a43427be31aadafbac3ac0636dc7abb22", size = 222543, upload-time = "2026-08-06T13:47:37.562Z" },
+    { url = "https://files.pythonhosted.org/packages/20/dd/88d6f83f1fffc974a3691a34a97951c5b12df7512a6782c5963883cbc058/coverage-7.15.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:37e2f0cdf58e2e1fed4e4d5a8f8786ae2f7eb80b478016876667dc4a01d60a97", size = 222905, upload-time = "2026-08-06T13:47:38.927Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/5c/54ee0d4748585bb0acab9891cd8d92f2d3593165b4e59fc9de113bfb3140/coverage-7.15.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fb55d0e70bb15f2e81477613627286581414693d74ac7963c93a790dd453ca9d", size = 254407, upload-time = "2026-08-06T13:47:40.488Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3f/f0642a372f494bd0d7dad3b497083b910194a5f1c88be2c94fef707c3b59/coverage-7.15.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:899b9da30f3c6c336566e3707495bb23e8302d39d862f01fa78c48b99b9437e2", size = 257145, upload-time = "2026-08-06T13:47:41.931Z" },
+    { url = "https://files.pythonhosted.org/packages/71/17/8b46d0ed68251016002ec972c8fc0119961a765d0984cafb8bf317c43758/coverage-7.15.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d15715e8c46552827e5e4f30a35575a2dbcad14454cf3284c54483946bd16931", size = 258257, upload-time = "2026-08-06T13:47:43.527Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b8/8498a0e72d0adbe15477dd07463d2b3bb2c9f6a4815e8589e50939e2c3ae/coverage-7.15.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:002a438859f7b430bc99afeaf01a6d187dad1d0dc907b64cdeffc632a5db8fd8", size = 260517, upload-time = "2026-08-06T13:47:45.121Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e1/7dce19c3bdb1e3dd63e769508216500edad81bd5f69a26d724e32aceaf78/coverage-7.15.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e4193a04b518f7968f3099755f5509ee7cccc6dc2b92a6b14841934d22e222c9", size = 254785, upload-time = "2026-08-06T13:47:46.541Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b1/e1494703c675a2561723cd9b89f45c9168782c31280c611b1f767851e57c/coverage-7.15.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e98dcc55d572b38e69d117da7e8e8efb8500f1f5eaf81ecd460a63220790b839", size = 256176, upload-time = "2026-08-06T13:47:48.155Z" },
+    { url = "https://files.pythonhosted.org/packages/73/76/a5629d270fb638a43a4b10466f51e2f49d532c1aa4da2913cbbb150bbe0a/coverage-7.15.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:af6c538498ce66c10d3fd541c2a8d5b03da5850355add34e6cba564210cb9e72", size = 254321, upload-time = "2026-08-06T13:47:49.757Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/9c44447218435d5766b911534f9d798144a5560f85e9a54ebe5f3f5d19f9/coverage-7.15.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1d10025d96ea89fc2f73714dbc4cbd433fe012c1ac9e23f895d7728b238b6e52", size = 258390, upload-time = "2026-08-06T13:47:51.248Z" },
+    { url = "https://files.pythonhosted.org/packages/de/36/c1e127616fb3fa18a9ff71e76c417f2fd7424332a4870015ac224ef4c039/coverage-7.15.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d802e1947603162ded419bff83ac7489820355d2b856dfb09206574e3a37ac0c", size = 253894, upload-time = "2026-08-06T13:47:52.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b9/fdb92c8ae7a8bb9b850cc253b7b3b9c8526f68130002048b5671cd510d09/coverage-7.15.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c2de40895718f91951b86712b4c5b694acaf9a0a49be13874896f599a1eed3f4", size = 255763, upload-time = "2026-08-06T13:47:54.296Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/a7d51b2587c7bdb76e71b0896d2565bf7d60436b5122fc83e511adb1f7cd/coverage-7.15.4-cp312-cp312-win32.whl", hash = "sha256:5c3431b2161279b7db5c2a1aa58ae02e5cb8c3c42d93a5094be3f5537bd5b11b", size = 224597, upload-time = "2026-08-06T13:47:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b9/5c5f80cc55f5acaaca6dee677626bfcec8c87204a7809b438b08e84f4571/coverage-7.15.4-cp312-cp312-win_amd64.whl", hash = "sha256:6befeab5fb2b51c958ca4ac6c5d141a1e8240f4f76e46350f1911963deda49cd", size = 225135, upload-time = "2026-08-06T13:47:57.52Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/2a4561f89ff6bf7c925c287d0f2cce8bdf139c3a33735c87e3203401cf94/coverage-7.15.4-cp312-cp312-win_arm64.whl", hash = "sha256:67bc345491ab55b837277d76f5775d057e8c7f1ac44d890d8c2c82adde258c6f", size = 224515, upload-time = "2026-08-06T13:47:58.977Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/84/651a9310859673aaa3b3203f1aa1641ca60fcf2494683e1c9474c7172780/coverage-7.15.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c705b28feb2775dc82a25f1d473a370bc37ff93f5177f4e29ce2425f560f6921", size = 222565, upload-time = "2026-08-06T13:48:00.796Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f9/4dcf700137e8af550670f4d74d1b63828ce93e1e2b05e5f10710eb2ea987/coverage-7.15.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3ff205ab5e3ecc670f6a4dd19d9cbf12ede53dd41cfc1e15716ec961ea6d314e", size = 222936, upload-time = "2026-08-06T13:48:02.391Z" },
+    { url = "https://files.pythonhosted.org/packages/07/4a/612ff1e780b3fbfd637486f542f84adc5503873d8b5d279dec1ffeef9414/coverage-7.15.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5172326e861a38b48b48befca15e0f477a26b283337a33a739c8fed229934e36", size = 253926, upload-time = "2026-08-06T13:48:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/04/d1cff1c2ead4708a6a79c01d3736b6a25bd38a36678398f72a8dd33dfad9/coverage-7.15.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:12b59c90084e3234fb11184886bf4a40f4f16a8c8f867be2e087b81f8e8868d4", size = 256523, upload-time = "2026-08-06T13:48:05.996Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/80/d34e13fb4b293cbdb9665838cf5522077b8ad14ef947550631a4bced36a5/coverage-7.15.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349062d66f00b40fa2c1c222438bad25fabf755631b5d82937fe985c8008615c", size = 257759, upload-time = "2026-08-06T13:48:08.036Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e7/2c5fe7636fdb0732fe0f09f308a5b066864078b7fc61f6678e8478554f2e/coverage-7.15.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4256ced708e598e05209bc1a8ab4074e04a51dba4c62fb45926a229af675ace7", size = 259890, upload-time = "2026-08-06T13:48:09.834Z" },
+    { url = "https://files.pythonhosted.org/packages/92/28/9689f0858dfff59c2ea688938ab9fa2925631235df67126a42b6c5c70ae1/coverage-7.15.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d80f974b20782d9612c8b4c9beeca867074c7cf4079d1419843fa25a26428b25", size = 254121, upload-time = "2026-08-06T13:48:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e2/785077c230c157243eb5aa9a26c3be260ecd02001bead54a3cada3df8e03/coverage-7.15.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e179f19bfe1d31f8eeeaa12990194d761c4f62f0759661000bca6cd8729f40b", size = 255891, upload-time = "2026-08-06T13:48:13.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/90/e20371b17b40f912f21305c2db2f30efa3de306f7320fc916804872c85a4/coverage-7.15.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8bc16bb47b7679670eceff71d78bfb7d6e5b143f6c2cd117487ec7c75e0d4b78", size = 253859, upload-time = "2026-08-06T13:48:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/05/49/25371987ee459a5f67c0427fb75c74f9358e65f2c71fe75bf41c1b6c5fcb/coverage-7.15.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd685005cd2c4200adfc14cf39a603b9320efab3f18a8f7f156d20c9cc3345f", size = 258011, upload-time = "2026-08-06T13:48:16.464Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6e/32e67467f6154bf4f1c4f63b05acc5097cba4237d45bbeeea446b52e8ac1/coverage-7.15.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:337399ad2c93b3acd2a937627dae8b3e86b66707cd3d3e856347999aadf1ef8d", size = 253676, upload-time = "2026-08-06T13:48:18.493Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/8b24192e89286399765155251f99ee9f070a9d637109018ac23d99b99f6f/coverage-7.15.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:96e257121228ec5cd2bb919276e94ac11074471bc37d68dbae0e8308cce15fff", size = 255453, upload-time = "2026-08-06T13:48:20.057Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6f/8b41ebdf67c87854e17c035336a90f1cfbad0c14c2a584301be6ff148718/coverage-7.15.4-cp313-cp313-win32.whl", hash = "sha256:c65a9e0dfc6143491879da4e13b5e30f8be192055de508d737fb14601edbd22c", size = 224605, upload-time = "2026-08-06T13:48:21.655Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/e2/2946c7f0b42b152ecb21ff1bdad72e3d301e790c0c487e4a86e8c9f69347/coverage-7.15.4-cp313-cp313-win_amd64.whl", hash = "sha256:2ff8f5e9b8f7a94f0c11c45631eee103dbcb7d63274edd12c56efe1be690b3b4", size = 225148, upload-time = "2026-08-06T13:48:23.376Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/83/3f4a69957f48ae7a0aba76c34743f88963d607b19e03f3f8e66f91cae0f9/coverage-7.15.4-cp313-cp313-win_arm64.whl", hash = "sha256:6e0a8a5083b096487d6cfced94cdd514d8f5db6f113610fb36c0620edb1028cf", size = 224536, upload-time = "2026-08-06T13:48:25.117Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ac/748cf29eeb2d6be34a3176ce26a4f49e38085ee08e8935f05f6f26ed7e0f/coverage-7.15.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:770e9325ab5ea6d56f77e59b29ecfe0ac20b57a82a601876f90494a4dda0386f", size = 222608, upload-time = "2026-08-06T13:48:26.806Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/02/1abbf5c984677b0aa439cdacaccbf38d248939d8ef8fe1cc7a50d73edb77/coverage-7.15.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d12b33a3a50a1676b7784dc8d00a0c6d66a9f2add4b85a041c19b6a7e53ef23c", size = 222940, upload-time = "2026-08-06T13:48:28.432Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e1/ff8f9f53d9fcf586125b55d0b1f04ec1c14955fee41e83d5814bee141bb5/coverage-7.15.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5669c8378ebde86f5def7a25d29586631b58acc27ffde04399f678f3dfc6e082", size = 253985, upload-time = "2026-08-06T13:48:29.995Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/26/595759762e514e81be1d7d01ed03444303bcd152226a6529998d253f9201/coverage-7.15.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ff97a14362eef486483ed44042ca2027ea257df6ff768e62358ee0c9776925ac", size = 256492, upload-time = "2026-08-06T13:48:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/b79aabac54d482be23b5fcdd4f4662bff24a78edc4ee29201726929936d5/coverage-7.15.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a325e815318638aed1655d9c06e6d7c2d3d46c09231ce988070428a8762d734", size = 257837, upload-time = "2026-08-06T13:48:33.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0f/bf7f297885a5bf6fd71e5782404e0ff059ca09e8711ceb3a08544abde45a/coverage-7.15.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:474223409d88eb20d2d6a0d37ea60e8647a65a90cc008dc1f0410af5f64f1e0d", size = 260152, upload-time = "2026-08-06T13:48:34.75Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/f1/296744e854ff8368542343457414380465e9ceefb9192342feb9d3bc461d/coverage-7.15.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7f2f62ae3cd189dd2e13aece758c57b3eecbd27be070dbd4cbd10936049e5dbf", size = 253978, upload-time = "2026-08-06T13:48:36.434Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b0/bbdb2e9057493e66220a2e149ca2d301ba0e3a58a83bd6b90de9826d16f3/coverage-7.15.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39ece820e29e0a2ba34b3ecb3be83c27e997eed8926f2ba6fe7ce7a0bda5843b", size = 255846, upload-time = "2026-08-06T13:48:38.317Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/38015b2b6d21258713bd17e76b59d033b191efb5703589cffd037dfbca20/coverage-7.15.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f21b56dcace11dfe013014201f577dcd592b2a9b72182d930361b47cf6f73f25", size = 253808, upload-time = "2026-08-06T13:48:39.993Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/64/0d515c1e60ee6fbfd1a0e79c07cd87d388a233b7adc37758735677203808/coverage-7.15.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:93a3a0b662abcc10c73a47cbc72cd60f63618d6989fb2d1286e50eacd974f303", size = 258081, upload-time = "2026-08-06T13:48:41.971Z" },
+    { url = "https://files.pythonhosted.org/packages/91/71/04d9e7a3642146c6351338aef4ef85ab11dbbb54744c13245caba1aad1c0/coverage-7.15.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:141fae2cabf5569b782c10afc4c850ce10f618c13f8db54765cba99cc839da1f", size = 253624, upload-time = "2026-08-06T13:48:43.731Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a7/6c28b74c81ebff66987b0e2522ba5cffa3e90b0c33cb6a2eb264d4ee8cf1/coverage-7.15.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:81294c7e6ab30c5f74c0353b11b2fd6320e72d9bee6ac73b357caa8b916323a5", size = 255280, upload-time = "2026-08-06T13:48:45.58Z" },
+    { url = "https://files.pythonhosted.org/packages/52/af/bc19996a7014b98d7bbb0f0939453c67074af65784a3aa16a789a07381fa/coverage-7.15.4-cp314-cp314-win32.whl", hash = "sha256:7bbd7d6418e0dab31a206af5203bd43ae36edb8e7fba1940b055d3e9249290d7", size = 224768, upload-time = "2026-08-06T13:48:47.525Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/219484e476d6e101ba0a444852579e05f5b75c37c611a42ed1190f73ef62/coverage-7.15.4-cp314-cp314-win_amd64.whl", hash = "sha256:f0204ed122758782970526057093f448051a39db9d810d4e344bb87a3546f425", size = 225259, upload-time = "2026-08-06T13:48:49.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/66/fa77daf4e383e5f776dac62c2409b6af81910ae6fe326bd5170dba74cc63/coverage-7.15.4-cp314-cp314-win_arm64.whl", hash = "sha256:9e71e7bc71c686a123347ae47a0de33a175e797a85bb57b791492adf4eec8ed8", size = 224684, upload-time = "2026-08-06T13:48:51.235Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5b/f03bf0ce362bbf3f785fa5219620d00778d4ac6fc9e407734828e9c672f6/coverage-7.15.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7c922735321eef3f87c280a3d39afff6b646723a2880b862cda4ac7a093b8aa8", size = 223338, upload-time = "2026-08-06T13:48:52.896Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/76/e77d0ae22501831cc9f92193e8a957a5caa1dd177f90a6d1d9b106242d92/coverage-7.15.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f41c17c4668a655ce96d090d8d5ffdc24ef64b5a02f9753884d08483e8a4a41a", size = 223609, upload-time = "2026-08-06T13:48:54.688Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1a/b1f089da8d38ac612fa2dd6dc7f4a1a7657d12f3e261d2996edd3a838d0b/coverage-7.15.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46822e9b6ff1c6a72b518c162c44a8f45a61a1d609c51084bf5b16c023c5037b", size = 264970, upload-time = "2026-08-06T13:48:56.403Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/31/e66d98d6e9c7fcc88470f1e234eaf6b1950dc0dfbf797f7282c1c861da24/coverage-7.15.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d6f4955b73b5445271379a59e3792b0d978f42d4a01e0cf7a67d9c33a3bb0a5", size = 267088, upload-time = "2026-08-06T13:48:58.41Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a1/ae94eb2c541add426378408379f233591e069040b1e2cdb33df9498a0682/coverage-7.15.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3fc9e047706fb4a9abb54f719d3aa643e80e5bb3818182c40aee01ac0f0247ba", size = 269508, upload-time = "2026-08-06T13:49:00.42Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c7/88a10694a1c6a213569766aba9f25847b28155d4ac731b13226db216356d/coverage-7.15.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05e491d4f3165d62d4f5c8fd48dfeabf2ae8f42cbbd484319af33ea851b78982", size = 270629, upload-time = "2026-08-06T13:49:02.234Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/34/d8b8232e5e55169933b59aabcef2fedfa4b9d8897361bb80fcbda146505f/coverage-7.15.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:226c66e80ec0598d3b9b4874123df167ccca342aca8714f77cac6829688ee09c", size = 264043, upload-time = "2026-08-06T13:49:04.102Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/35/58b009dbf8c471c7224716478b9fed4a7e1af15320e1ed41660978504663/coverage-7.15.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac41cc14bebda0dbfb0628036b7f75706935c95bcc07fefe9a0f93614aa60a57", size = 266963, upload-time = "2026-08-06T13:49:05.821Z" },
+    { url = "https://files.pythonhosted.org/packages/62/aa/57fbda1b42c892968273c56b6ee9dc0f1310850859230a507bc7873b1f65/coverage-7.15.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8af623e5cd92080acddd02b38f2f406a2c3a0893c38950b211890361448fbf26", size = 264569, upload-time = "2026-08-06T13:49:07.706Z" },
+    { url = "https://files.pythonhosted.org/packages/98/8a/360e6e7f24d477b7e889703af0afa878d15b6d4d8d2a822b2835c169a879/coverage-7.15.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07545711d4f0f32852a18f18ad11f76f0109909d09e78b9008b4cfc67e829429", size = 268299, upload-time = "2026-08-06T13:49:09.587Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/89/6f701261aee21b6b5fa8f7872229406dc917e125069448292223bf213606/coverage-7.15.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a0865421cfdc53654b342d515e5a233187590882d20b95752150e53f65460017", size = 263413, upload-time = "2026-08-06T13:49:11.604Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/0f/6f04036edc260ed425af83e834f627fad48941ce97b50bfe6edd8b6fa623/coverage-7.15.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:460115e32ee40566476db5048f9bec1e842c127ad8e6f8be745aad3ac9cbc839", size = 265725, upload-time = "2026-08-06T13:49:13.38Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ce/d19b5d4d5c49a7bfb925fd74310fee7d28bc99520ac3367ccbc54e662518/coverage-7.15.4-cp314-cp314t-win32.whl", hash = "sha256:cbde877ef9dd7baf272b9bfef2b8a25edd45d9170fc326951dd20eb480335e85", size = 225079, upload-time = "2026-08-06T13:49:15.265Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bb/7aa1b3b173faee0679037ca950bbbe1247273656697994d8d13f80f8d4b4/coverage-7.15.4-cp314-cp314t-win_amd64.whl", hash = "sha256:3da9e92d1c551fd7563833e9ade686efb0c4b7363ab7681a94283958c950bf5e", size = 225911, upload-time = "2026-08-06T13:49:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1c/4ea9e47426d80038d9222db3c4534cb6021a74b237d3ff97ffd33b6600dd/coverage-7.15.4-cp314-cp314t-win_arm64.whl", hash = "sha256:3a54f5a0d85050c73a38f6793090ee83974531e67fe5e57a1da9bee11398aa5e", size = 225219, upload-time = "2026-08-06T13:49:19.293Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c4/dc5d2ac8f9142e7ec7de66e7bf0591db29d78955a040bd915870d9c0e657/coverage-7.15.4-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:2c9872e4d9dc5d3cf616bf4b382f5a00359305a5be666a3dd0b5cdb4e49597f9", size = 222604, upload-time = "2026-08-06T13:49:21.279Z" },
+    { url = "https://files.pythonhosted.org/packages/70/39/33e63df81fe2ee100897451841c821467635923e58e37c6bd4b46dd8106c/coverage-7.15.4-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:e101dbb4b9b72f0cddd8cdc8c9c5b47f456766f5e0ac82dbfb75e5c55409b78a", size = 222944, upload-time = "2026-08-06T13:49:23.187Z" },
+    { url = "https://files.pythonhosted.org/packages/99/1f/ef3ffb5557febc75a0d97aa459d0266d7d741110265121cc6d8539343d44/coverage-7.15.4-cp315-cp315-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7d1abebdb047729e852b9c77a00497dfbeb11eb3a117e037d7dbc3ac8e5f5c54", size = 254050, upload-time = "2026-08-06T13:49:25.008Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/f5/1f0f6f77698c3601ca0ae7431e34b24c62ca2f06fecb23b73ed1f651d2be/coverage-7.15.4-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d28a4a899354d0ea6214cc59b4fa19eefbce1b9ff1688ab579acf49e894bd3fb", size = 256967, upload-time = "2026-08-06T13:49:26.896Z" },
+    { url = "https://files.pythonhosted.org/packages/03/7a/2ed9bed79925f4367c83c77f66a89e5ca7229c288d2d19ad5f36d1ca0070/coverage-7.15.4-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffb3c2aacea411cc7e1d27712490c11108e2de1d39019ae32915493a59a8b9ed", size = 258587, upload-time = "2026-08-06T13:49:28.692Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8c/fa34044f71b7cc4ecb6da9c2408770959b0591fa9b5fb6fb6bca38f94298/coverage-7.15.4-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a9447978a92f405d301123cfd39ff49895490efb769a758fe2734c7f631bf8ce", size = 260785, upload-time = "2026-08-06T13:49:30.472Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/54/d5727ce36b4524a7394ab9f5f1df378e1f23affcdab01037dc8655185cc7/coverage-7.15.4-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:050467a7983b8e2fe7dd41a78bb30c3e7f8c0b8cafda14b1c46f8b5e3cf2dd3c", size = 254545, upload-time = "2026-08-06T13:49:32.271Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/e6/6e3783e576719590194bdffb6dd6d85490801785b7c331e35a245d8cb8b5/coverage-7.15.4-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:d003b7a5708ddad5c206c79607a6b92abb6fc13c57d99d8a4468cc03a2941ced", size = 256682, upload-time = "2026-08-06T13:49:34.089Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/bacdbde18b69ed2de424fcf64d9fb0a4913753d4f0eca8bae9daad69f4bd/coverage-7.15.4-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c38efe30fd74e5c19e9433f11fb1f5dc9c6522770971b7c6145bbaa413dc8800", size = 254560, upload-time = "2026-08-06T13:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a3/1fb927196e3477c1b48831169ab58ba08f451ba87ae311ff1de68b26a616/coverage-7.15.4-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:1f4f826d70f772ab8b0c052329580d7fe8b8abd191e4ce0c8f81aec6614665d3", size = 258792, upload-time = "2026-08-06T13:49:38.01Z" },
+    { url = "https://files.pythonhosted.org/packages/41/58/30d4c149c69053de0edfe325614c1d28d508f62b1783e0e4a234d2e49136/coverage-7.15.4-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:4a4bf917c9953f57c957be31c1cd504e3bd2f34d4a352b9d391a3025336f6768", size = 253968, upload-time = "2026-08-06T13:49:39.934Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e4/77f639371b918aad30dda4051f95404b43578f7f2e2f87ba73e02ed1ff37/coverage-7.15.4-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:1c9bf40ebef178a45192c75c4964760bb261b0e6ad725da5fc4c93f674f19753", size = 255893, upload-time = "2026-08-06T13:49:41.825Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/62/13be29b3ddab35f14c87967a4820a05106d2a3eccb4fa4ff550bf30b75e0/coverage-7.15.4-cp315-cp315-win32.whl", hash = "sha256:43619d04c3671792d2c4706ae8bf45e265dc87bbd4078189ef8b847ea1e74be2", size = 224768, upload-time = "2026-08-06T13:49:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/70/af0c6be0f964af6954f6b74bc109b0dbca02824696d2520fb17fe1ab06e3/coverage-7.15.4-cp315-cp315-win_amd64.whl", hash = "sha256:be619439dbcd31a2eab10b32de9fff62c26ed4bab69dc32b8363fdaaa0882809", size = 225242, upload-time = "2026-08-06T13:49:45.899Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2d/f3bd3aab899fc9efc18b53133ee68f5f98574ef480649b23e12962226387/coverage-7.15.4-cp315-cp315-win_arm64.whl", hash = "sha256:def597967dafc2e8d97c9097ea453c464e0bb8ed38f193a43070f10dc623bb6d", size = 224674, upload-time = "2026-08-06T13:49:48.322Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/ca/f69251cd63eabc6438321aea22148754cce758a26bde07dd490e3fe7cfc5/coverage-7.15.4-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c7dbc748ac8a1e3e59a2b28bea47675e6e778081dbbf081bde0d75def2fcbe1d", size = 223333, upload-time = "2026-08-06T13:49:50.293Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a7/037b53b2885b0d8447064432491a4d5a1014cd9f97a594d53acd0c04541a/coverage-7.15.4-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:2413074a5ecbb61a01a7888fc72db0ca324d13588c5b38bc0dd8564cdcdfea26", size = 223630, upload-time = "2026-08-06T13:49:52.637Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4f/152b8a4779ae90da11bb24f7467df8a59f0be48a5c52acb856325ca48289/coverage-7.15.4-cp315-cp315t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4e6f6f632b7b2f714bf7a1346e8f97b650ee71f3c298aaad42a2ab60f0f07645", size = 264489, upload-time = "2026-08-06T13:49:54.52Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2d/84b4b9e0e1dd6528a51920ff7031f35b789382e467a28ec6a5a578cb8812/coverage-7.15.4-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8df457da2249d3c75ca2e5e835d59c725abfe92d27fdff6cd99eed85b51d5e9a", size = 267567, upload-time = "2026-08-06T13:49:56.721Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fc/ba01cc25299f9f8a2c8b02d3b28c53f3543d9fbfbe4e74fa2760b48f163e/coverage-7.15.4-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:050f66a08805acb5b8a23c6d4a517b1ecf82c08e81ed0e4bd727df065e5c6624", size = 270123, upload-time = "2026-08-06T13:49:58.736Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d0/db2647cbf40b14f8c308f94ff7bf89c06d564e59f396906edf50086ec788/coverage-7.15.4-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1587fb771d1ccceef708fdde1e5af8c7ed24b486b61d13a321acb7d8145390aa", size = 271107, upload-time = "2026-08-06T13:50:00.811Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/4d2d17924552c458bb4f77dd631f0e3bc92fbbdf2d2d916cd4b33bbfd5b1/coverage-7.15.4-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8b4f1c3a69ca580f3fbd6b2046915f536d7f586874f25c1bb23add2a3c88d50f", size = 264955, upload-time = "2026-08-06T13:50:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/de/dc010c7a3691f396d93bbc26bfcafa1c2a3a351cd520470f15faf5795bd5/coverage-7.15.4-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:ffb58d7eff5b7f6ecc6fa21d6288ab7f968a212cb67d682c269c09b9eba3b66f", size = 267949, upload-time = "2026-08-06T13:50:05.557Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ea/dc96a11375e83c045c2f7c61fb6918277cfe9401db7c0f7b1d111a84b2e5/coverage-7.15.4-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:d9df165544774574ee004b953023d1bebada1894a80b1052a43d798b0f676e67", size = 264421, upload-time = "2026-08-06T13:50:07.612Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/86/b77131a0f9503ce461cd577076147d7a9040f0c5dda772686f729e2cc9cb/coverage-7.15.4-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:f9de0a24a4079b53e523b5c5e2c5945ec251ab486652659955187cf255a259bc", size = 269121, upload-time = "2026-08-06T13:50:09.58Z" },
+    { url = "https://files.pythonhosted.org/packages/24/24/944bc35007862955e7ebf05754e645419dcf5d7526c52735cfa2715e8ebf/coverage-7.15.4-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:150089274bdc9f940628552cb92844e0223c987f1902ab8efe9f45a2ec758d88", size = 264565, upload-time = "2026-08-06T13:50:11.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/cc/a3bb9f93e7e740659163e2ea584f8196ddcd2c456a5dbe15f6c50105fec1/coverage-7.15.4-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:a58a94fed5da6997d258e8f7668c1e195fbd04a691d781b7558f1e468f9e68bc", size = 266522, upload-time = "2026-08-06T13:50:13.786Z" },
+    { url = "https://files.pythonhosted.org/packages/49/dd/e0e40f3560d878d888c580698ff5ad1179f5e1c3ac949684ef66b41a3817/coverage-7.15.4-cp315-cp315t-win32.whl", hash = "sha256:ebd5a6d8466ff30836572f3ba2cae8a5e8f85029b1c6d5e2ed338dc472a5166a", size = 225068, upload-time = "2026-08-06T13:50:15.825Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7e/37732ea80eebc30e976e4cdab15c190bc42d96959a42e38ddf6f8c60468f/coverage-7.15.4-cp315-cp315t-win_amd64.whl", hash = "sha256:288bde2a2d7ab6b6c2d7252fcde8b524387f2d970bdba9658fc6f8bbcaef0f9b", size = 225895, upload-time = "2026-08-06T13:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/08/1e00f7923eaaba45fb3d51dd794125fc766304b1df264f3a9c6557bfb30e/coverage-7.15.4-cp315-cp315t-win_arm64.whl", hash = "sha256:68be5e1de60ff13c9095bbec0e5a7fa45b33b101752215b91345ea1f61c4a278", size = 225213, upload-time = "2026-08-06T13:50:19.981Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d9/e70c286c979378f061d8266e279b686ab0b0b688e1fe0af864684f23a77d/coverage-7.15.4-py3-none-any.whl", hash = "sha256:964730a1e9de9c0cf11be6a1a3c79ce419c34882842abd256086ba4698705e84", size = 214332, upload-time = "2026-08-06T13:50:22.192Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "zipp", version = "3.23.1", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "zipp", version = "4.1.0", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.10'" },
+    { name = "coverage", version = "7.15.4", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
+    { name = "pluggy" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
+    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "whatisit"
+version = "0.2.2"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "build", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "build", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "build", marker = "extra == 'dev'", specifier = ">=1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -19,7 +19,7 @@ import sys
 from pathlib import Path
 
 from . import config as cfg_mod
-from . import engine, fetch
+from . import engine, fetch, sessions
 from .safety import check
 
 # Colour only when attached to a terminal, and honour NO_COLOR. Tracked per
@@ -131,10 +131,13 @@ def _warn_stray_flags(args) -> None:
     warn(DIM(f"        flags go first:  whatisit {first} {rest}"))
 
 
-def _emit_debug(prompt: str, system: str, user_msg: str, grammar: str | None) -> None:
+def _emit_debug(prompt: str, system: str, user_msg: str, grammar: str | None,
+                extra_context: str | None = None) -> None:
     """Print the exact prompt + grammar the model sees, for diagnosing failures."""
     warn(DIM(f"  --debug: system prompt length = {len(system)}"))
     warn(DIM(f"  --debug: grammar = {'none' if grammar is None else 'set'}"))
+    if extra_context:
+        warn(DIM(f"  --debug: session context:\n{extra_context}"))
     warn(DIM(f"  --debug: user prompt:\n{user_msg}"))
     if grammar:
         warn(DIM(f"  --debug: GBNF grammar:\n{grammar}"))
@@ -146,6 +149,20 @@ def cmd_query(args, cfg: dict) -> int:
     if not prompt:
         warn("whatisit: nothing to do -- give me a request in plain English")
         return 2
+
+    # Session memory is opt-in (config sessions=true, or --session for one
+    # run). Loading validates TTL/cwd and resets a dead session even when
+    # nothing will be injected; turns are recorded regardless so a
+    # self-contained first request can seed a later follow-up. Injection
+    # additionally requires a non-quiet run (-q output must stay deterministic
+    # and self-contained for $(...) use) and an anaphoric request, so ordinary
+    # queries get byte-identical prompts to before. See sessions.py.
+    sessions_on = bool(cfg.get("sessions")) or getattr(args, "session", False)
+    extra_context = None
+    if sessions_on:
+        turns = sessions.load_valid()
+        if turns and not args.quiet and sessions.looks_anaphoric(prompt):
+            extra_context = sessions.history_block(turns)
 
     # Per-invocation overrides from CLI flags. These win over the saved config
     # file but do not persist to it (that is `whatisit config --set`'s job).
@@ -166,7 +183,8 @@ def cmd_query(args, cfg: dict) -> int:
         # (if any). Intended for diagnosing why the 1.5B model misbehaves; goes
         # to stderr so `-q` output is unaffected.
         system, user_msg = engine.hostctx.build(prompt,
-                                                enabled=cfg.get("host_context", True))
+                                                enabled=cfg.get("host_context", True),
+                                                extra_context=extra_context)
         pkg = "unknown"
         grammar = None
         if cfg.get("host_context", True) and cfg.get("use_grammar", True):
@@ -176,7 +194,8 @@ def cmd_query(args, cfg: dict) -> int:
                 pass
             if pkg != "unknown" and hasattr(engine.hostctx, "grammar_for_pkg"):
                 grammar = engine.hostctx.grammar_for_pkg(pkg)
-        _emit_debug(prompt, system, user_msg, grammar)
+        _emit_debug(prompt, system, user_msg, grammar,
+                    extra_context=extra_context)
 
     # Remote mode sends the request (and host context, if enabled) somewhere
     # else, which is the one thing this tool otherwise promises never to do.
@@ -189,7 +208,8 @@ def cmd_query(args, cfg: dict) -> int:
     try:
         cmds, elapsed, mode = engine.generate(
             prompt, cfg, n=args.num, force_oneshot=args.oneshot, quiet=args.quiet,
-            for_execution=args.execute or args.quiet)
+            for_execution=args.execute or args.quiet,
+            extra_context=extra_context)
     except FileNotFoundError as e:
         warn(f"whatisit: {e}")
         return 3
@@ -215,13 +235,20 @@ def cmd_query(args, cfg: dict) -> int:
         if findings:
             sys.stdout.flush()
             print_findings(findings)
+        # -q still records (stdout is untouched by it): a scripted first call
+        # is exactly the setup whose follow-up gets typed manually next.
+        if sessions_on:
+            sessions.record(prompt, cmds[0])
         _warn_stray_flags(args)
         return 0
 
+    first_danger = False
     for i, c in enumerate(cmds):
         label = f"{DIM(f'{i+1}.')} " if len(cmds) > 1 else ""
         out(f"{label}{BOLD(CYAN(c))}")
         findings = check(c)
+        if i == 0:
+            first_danger = any(sev == "DANGER" for sev, _ in findings)
         if findings:
             # The command goes to stdout and warnings to stderr (so that
             # `whatisit ... | sh` still works). Without this flush the two streams
@@ -234,6 +261,12 @@ def cmd_query(args, cfg: dict) -> int:
     # never printed after messages that refer to it.
     sys.stdout.flush()
     _warn_stray_flags(args)
+
+    # Record the turn for future follow-ups -- but NEVER one the checker
+    # flagged DANGER: stored history must not become a way to replay a
+    # dangerous command past the safety gate on a later "run it again".
+    if sessions_on and not first_danger:
+        sessions.record(prompt, cmds[0])
 
     # Opt-in only (`whatisit config --set log_queries=true`). Shell requests can
     # contain hostnames, paths and credentials, so this is never on by default
@@ -299,7 +332,13 @@ def cmd_query(args, cfg: dict) -> int:
 
     warn(DIM(f"$ {chosen}"))
     shell = os.environ.get("SHELL", "/bin/bash")
-    return subprocess.run([shell, "-c", chosen]).returncode
+    rc = subprocess.run([shell, "-c", chosen]).returncode
+    # -e can only reach this point past the DANGER refusal above, so what
+    # actually executed is always safe to remember -- and more truthful than
+    # the suggestion that was recorded before it.
+    if sessions_on:
+        sessions.update_executed(chosen, rc)
+    return rc
 
 
 def _confirm(prompt: str, auto: bool) -> bool:
@@ -676,6 +715,45 @@ def cmd_stop(args, cfg: dict) -> int:
     return 0
 
 
+def cmd_session(args, cfg: dict) -> int:
+    """Inspect or wipe stored follow-up context (format in sessions.py).
+
+    show prints what is on disk, stale turns included: this is an audit view
+    of the file, not a preview -- whether a turn would actually be injected
+    is decided per query by load_valid (TTL, cwd) and looks_anaphoric.
+    """
+    if args.action == "clear":
+        print("whatisit: session cleared." if sessions.clear()
+              else "whatisit: no session stored.")
+        return 0
+    turns = sessions.show()
+    if not turns:
+        print("whatisit: no session stored.")
+        return 0
+    for i, t in enumerate(turns, 1):
+        mark = DIM(f"  [ran, exit {t.get('exit_code')}]" if t.get("executed") else "")
+        print(f"{BOLD(f'{i}.')} {t['nl']}")
+        print(f"   -> {CYAN(t['command'])}{mark}")
+    return 0
+
+
+def _cmd_session_argv(rest: list[str]) -> int:
+    """Hand-routed `session` subcommand.
+
+    argparse cannot route this one itself: the greedy `words` positional
+    (see QueryArgs) competes for the literal token "session", and with a
+    following word -- `session show` -- the word arrives at the top-level
+    sub choice instead of inside the subparser. stop/config never hit this
+    because they take no positional argument.
+    """
+    import types
+    action = rest[0] if rest else "show"
+    if action not in ("show", "clear"):
+        warn(f"whatisit: unknown session action {action!r} -- use show or clear")
+        return 2
+    return cmd_session(types.SimpleNamespace(action=action), {})
+
+
 def cmd_config(args, cfg: dict) -> int:
     if args.set:
         for kv in args.set:
@@ -728,6 +806,9 @@ def build_parser() -> argparse.ArgumentParser:
                     help="bypass the resident server (slower; for debugging)")
     ap.add_argument("-y", "--yes", action="store_true",
                     help="with -e, treat an empty confirm answer as yes ([Y/n])")
+    ap.add_argument("--session", action="store_true",
+                    help="enable session memory for this invocation "
+                         "(lets \"execute them\" resolve against your last request)")
     ap.add_argument("--port", type=int, metavar="PORT",
                     help="fixed TCP port for the resident server (1-65535)")
     ap.add_argument("--threads", type=int, metavar="N",
@@ -768,16 +849,24 @@ def build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("doctor", help="check the installation").set_defaults(func=cmd_doctor)
     sub.add_parser("stop", help="stop the resident model server").set_defaults(func=cmd_stop)
+    # Registered so `whatisit --help` lists it, but routed by hand in main()
+    # (_cmd_session_argv): argparse cannot get "session <action>" through the
+    # greedy words positional.
+    ssn = sub.add_parser("session", help="show or clear remembered follow-up context")
+    ssn.add_argument("action", nargs="?", choices=["show", "clear"], default="show",
+                     help="show prints stored turns; clear wipes them")
+    ssn.set_defaults(func=cmd_session)
     c = sub.add_parser("config", help="show or change settings")
     c.add_argument("--set", nargs="+", metavar="K=V")
     c.set_defaults(func=cmd_config)
     return ap
 
 
-SUBCOMMANDS = {"setup", "doctor", "stop", "config"}
+SUBCOMMANDS = {"setup", "doctor", "stop", "session", "config"}
 _FLAGS_NOARG = {"-e", "--execute", "-q", "--quiet", "-t", "--timing", "--oneshot",
                 "--host-context", "--no-host-context",
-                "--grammar", "--no-grammar", "--debug", "-y", "--yes"}
+                "--grammar", "--no-grammar", "--debug", "-y", "--yes",
+                "--session"}
 _FLAGS_ARG = {"-n", "--num"}
 _FLAGS_QUERY_ARG = {"--port", "--threads", "--ctx-size", "--model"}
 
@@ -801,6 +890,7 @@ class QueryArgs:
         self.timing, self.oneshot = False, False
         self.port, self.threads, self.ctx_size, self.model = None, None, None, None
         self.host_context, self.grammar, self.debug, self.yes = None, None, False, False
+        self.session = False
         i = 0
         while i < len(argv):
             a = argv[i]
@@ -823,6 +913,7 @@ class QueryArgs:
                                    "-q": "quiet", "--quiet": "quiet",
                                    "-t": "timing", "--timing": "timing",
                                    "--oneshot": "oneshot",
+                                   "--session": "session",
                                    "--debug": "debug"}[a], True)
             elif a in _FLAGS_ARG:
                 if i + 1 >= len(argv):
@@ -887,6 +978,8 @@ def main(argv=None) -> int:
     # `whatisit config` manages settings while `whatisit show me the git config`
     # stays a question.
     if argv[0] in SUBCOMMANDS:
+        if argv[0] == "session":
+            return _cmd_session_argv(argv[1:])
         args = build_parser().parse_args(argv)
         return args.func(args, cfg)
 

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -265,7 +265,11 @@ def cmd_query(args, cfg: dict) -> int:
     # Record the turn for future follow-ups -- but NEVER one the checker
     # flagged DANGER: stored history must not become a way to replay a
     # dangerous command past the safety gate on a later "run it again".
-    if sessions_on and not first_danger:
+    # The flag doubles as the gate for update_executed below: when this run
+    # recorded nothing, turns[-1] belongs to a previous invocation and must
+    # not be rewritten with this run's executed command.
+    recorded = sessions_on and not first_danger
+    if recorded:
         sessions.record(prompt, cmds[0])
 
     # Opt-in only (`whatisit config --set log_queries=true`). Shell requests can
@@ -335,8 +339,9 @@ def cmd_query(args, cfg: dict) -> int:
     rc = subprocess.run([shell, "-c", chosen]).returncode
     # -e can only reach this point past the DANGER refusal above, so what
     # actually executed is always safe to remember -- and more truthful than
-    # the suggestion that was recorded before it.
-    if sessions_on:
+    # the suggestion that was recorded before it. Gated on `recorded`: see
+    # the comment at the recording site.
+    if recorded:
         sessions.update_executed(chosen, rc)
     return rc
 

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -110,6 +110,11 @@ DEFAULTS = {
     "force_tcp": False,
     "server_port": None,       # fixed TCP port for the resident server
     "ctx_size": 2048,          # context size passed to llama-server/llama-cli
+    # OFF by default: cross-invocation memory ("execute them") writes requests
+    # to disk and changes prompts, so it is strictly opt-in (--session or
+    # sessions=true). Injection is further gated on anaphora detection; see
+    # sessions.py.
+    "sessions": False,
 }
 
 

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -957,11 +957,14 @@ def _collect_commands(raws, host_pkg: str = "unknown") -> list[str]:
 
 
 def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
-             quiet: bool = False, for_execution: bool = False) -> tuple[list[str], float, str]:
+             quiet: bool = False, for_execution: bool = False,
+             extra_context: str | None = None) -> tuple[list[str], float, str]:
     """Return (commands, elapsed_seconds, mode). Commands are already extracted.
 
     mode is one of "remote", "server", or "oneshot". Remote mode is selected by
     a configured OpenAI-compatible base URL and needs no local model at all.
+    extra_context is preformatted session history (sessions.history_block);
+    the gating decision lives in the CLI so this stays a pure transport.
     """
     remote = cfg_mod.remote_config(cfg)
     if remote is not None:
@@ -975,9 +978,13 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
         # -e and -q feed a shell. The volatile block carries filenames from the
         # cwd, which the user did not type, so it is withheld from the two
         # flows whose output can run. Ordinary suggestions still get it.
+        # Session history is the deliberate exception for -e: "delete them"
+        # must resolve against the prior turn, and every executed command
+        # still passes the same safety gate. -q stays context-free.
         system, user_msg = hostctx.build(
             prompt, enabled=cfg.get("host_context", True),
-            include_volatile=not (for_execution or quiet))
+            include_volatile=not (for_execution or quiet),
+            extra_context=extra_context)
         t0 = time.time()
         raws = _query_remote(remote, user_msg, cfg, n, system=system)
         return _collect_commands(raws), time.time() - t0, "remote"
@@ -1002,7 +1009,8 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
     # placeholder / wrong-tool failures. cfg["host_context"]=false disables it.
     system, user_msg = hostctx.build(
         prompt, enabled=cfg.get("host_context", True),
-        include_volatile=not (for_execution or quiet))
+        include_volatile=not (for_execution or quiet),
+        extra_context=extra_context)
 
     # GBNF grammar + distro-aware postprocessing: constrain install verbs to the
     # host's package manager and rewrite any wrong-distro syntax as a backstop.

--- a/whatisit_pkg/whatisit/hostctx.py
+++ b/whatisit_pkg/whatisit/hostctx.py
@@ -517,13 +517,30 @@ def grammar_for_pkg(pkg_mgr: str) -> str | None:
 
 
 def build(prompt: str, enabled: bool = True, cwd: Path | None = None,
-          include_volatile: bool = True) -> tuple[str, str]:
-    """Return (system_prompt, user_message) with context folded in."""
+          include_volatile: bool = True,
+          extra_context: str | None = None) -> tuple[str, str]:
+    """Return (system_prompt, user_message) with context folded in.
+
+    extra_context carries session history (sessions.history_block). It is
+    independent of both switches: unlike volatile facts it survives
+    include_volatile=False, because "-e delete them" must resolve "them"
+    against the previous turn while still never seeing the directory listing;
+    and unlike host context it is not switched off by enabled=False. It is
+    placed immediately before the <request> tag (or directly ahead of a bare
+    prompt on the unwrapped paths). None leaves every output byte-identical.
+    """
     if not enabled:
+        if extra_context:
+            return cfg_mod.SYSTEM_PROMPT, extra_context + "\n\n" + prompt
         return cfg_mod.SYSTEM_PROMPT, prompt
     system = cfg_mod.SYSTEM_PROMPT + "\n\n" + stable_block()
     if include_volatile:
-        user = volatile_block(cwd) + "\n\n<request>\n" + prompt + "\n</request>"
+        body = volatile_block(cwd)
+        if extra_context:
+            body = body + "\n\n" + extra_context
+        user = body + "\n\n<request>\n" + prompt + "\n</request>"
+    elif extra_context:
+        user = extra_context + "\n\n" + prompt
     else:
         user = prompt
     return system, user

--- a/whatisit_pkg/whatisit/hostctx.py
+++ b/whatisit_pkg/whatisit/hostctx.py
@@ -516,31 +516,45 @@ def grammar_for_pkg(pkg_mgr: str) -> str | None:
     return PKG_MGR_GRAMMARS.get(pkg_mgr)
 
 
+def _wrap_prior(block: str) -> str:
+    """Tag the session block like every other context block.
+
+    History contains model-generated command text that was written to disk
+    and is fed back into a later prompt. Bare, it reads as loose instruction
+    text and a stored command that itself contains 'Prior:' could blur the
+    block boundary; inside <prior_turns> it is marked as data, for about ten
+    tokens of overhead.
+    """
+    return f"<prior_turns>\n{block}\n</prior_turns>"
+
+
 def build(prompt: str, enabled: bool = True, cwd: Path | None = None,
           include_volatile: bool = True,
           extra_context: str | None = None) -> tuple[str, str]:
     """Return (system_prompt, user_message) with context folded in.
 
-    extra_context carries session history (sessions.history_block). It is
-    independent of both switches: unlike volatile facts it survives
-    include_volatile=False, because "-e delete them" must resolve "them"
-    against the previous turn while still never seeing the directory listing;
-    and unlike host context it is not switched off by enabled=False. It is
-    placed immediately before the <request> tag (or directly ahead of a bare
-    prompt on the unwrapped paths). None leaves every output byte-identical.
+    extra_context carries session history (sessions.history_block, bare
+    lines; this module owns the envelope). It is independent of both
+    switches: unlike volatile facts it survives include_volatile=False,
+    because "-e delete them" must resolve "them" against the previous turn
+    while still never seeing the directory listing; and unlike host context
+    it is not switched off by enabled=False. It is wrapped in
+    <prior_turns> and placed immediately before the <request> tag (or
+    directly ahead of a bare prompt on the unwrapped paths). None leaves
+    every output byte-identical.
     """
     if not enabled:
         if extra_context:
-            return cfg_mod.SYSTEM_PROMPT, extra_context + "\n\n" + prompt
+            return cfg_mod.SYSTEM_PROMPT, _wrap_prior(extra_context) + "\n\n" + prompt
         return cfg_mod.SYSTEM_PROMPT, prompt
     system = cfg_mod.SYSTEM_PROMPT + "\n\n" + stable_block()
     if include_volatile:
         body = volatile_block(cwd)
         if extra_context:
-            body = body + "\n\n" + extra_context
+            body = body + "\n\n" + _wrap_prior(extra_context)
         user = body + "\n\n<request>\n" + prompt + "\n</request>"
     elif extra_context:
-        user = extra_context + "\n\n" + prompt
+        user = _wrap_prior(extra_context) + "\n\n" + prompt
     else:
         user = prompt
     return system, user

--- a/whatisit_pkg/whatisit/sessions.py
+++ b/whatisit_pkg/whatisit/sessions.py
@@ -156,7 +156,14 @@ def load_valid() -> list[dict]:
     fresh = False
     if turns:
         last = turns[-1]
-        if time.time() - float(last.get("ts", 0)) > TTL_SECONDS:
+        # float(None)/float("abc") must not escape here: one malformed line
+        # would abort every session-enabled query until the file was deleted
+        # by hand. An unreadable timestamp is by definition not a live turn.
+        try:
+            age = time.time() - float(last.get("ts", 0))
+        except (TypeError, ValueError):
+            age = TTL_SECONDS + 1
+        if age > TTL_SECONDS:
             fresh = True
         elif _norm_cwd(last.get("cwd")) != _norm_cwd(os.getcwd()):
             fresh = True
@@ -191,8 +198,10 @@ def record(nl: str, command: str) -> None:
 
 def update_executed(command: str, exit_code: int) -> None:
     """Overwrite the newest turn after -e runs it, recording what actually
-    executed and how it fared. No-op when nothing was recorded -- e.g. the
-    newest generation was DANGER-flagged and skipped."""
+    executed and how it fared. Mutates turns[-1] unconditionally, so the
+    caller must gate this on having recorded a turn for the CURRENT
+    invocation -- otherwise a DANGER-skipped run would rewrite the previous
+    invocation's turn with a command it never produced."""
     turns = _read_turns()
     if not turns:
         return

--- a/whatisit_pkg/whatisit/sessions.py
+++ b/whatisit_pkg/whatisit/sessions.py
@@ -1,0 +1,220 @@
+"""Cross-invocation memory for follow-up requests ("execute them").
+
+The tool is a cold-start process: every invocation is a fresh interpreter, so
+"whatisit list three python files here" followed by "whatisit execute them"
+reaches the model with no sense of the first request, and the 1.5B rambles.
+This module persists the last few turns on disk so the CLI can fold a compact
+context block into the next prompt when (and only when) the new request
+actually refers back to one of them.
+
+Storage is NDJSON: one JSON turn per line, capped at MAX_TURNS lines. The cap
+means a reader only ever needs the file tail and a writer only rewrites three
+short lines -- no document parsing, no schema migration, no array bookkeeping.
+A corrupt trailing byte costs one turn, never the file.
+
+Two rules shaped by how this feature can go wrong:
+
+NEVER STORE A DANGER COMMAND. Enforced by the caller (cmd_query): a command
+the safety checker flagged must not reach this file, or a later "run it again"
+would hand the model a stored dangerous command to replay past the checker.
+
+LAST-WRITER-WINS concurrency. Two simultaneous invocations may interleave
+rewrites; the loser loses one turn. A lockfile was rejected: it trades a
+harmless forgotten turn for a stale-lock failure mode on a tool whose worst
+case here is forgetting.
+
+Privacy follows queries.jsonl: local disk only, owner-only (0700 dir, 0600
+file, O_NOFOLLOW), wiped by `whatisit session clear`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+from . import config as cfg_mod
+
+MAX_TURNS = 3
+TTL_SECONDS = 15 * 60     # a follow-up minutes later relates; an hour later does not
+MAX_NL_CHARS = 200        # request text, truncated before storage
+MAX_CMD_CHARS = 300       # generated command, truncated before storage
+_TAIL_BYTES = 4096        # orders of magnitude more than three turns occupy
+
+
+def _path() -> Path:
+    return cfg_mod.data_dir() / "session.jsonl"
+
+
+def _norm_cwd(cwd) -> str:
+    # realpath so a session started under /tmp survives macOS resolving it to
+    # /private/tmp (and equivalent symlink aliasing elsewhere).
+    try:
+        return os.path.realpath(str(cwd))
+    except OSError:
+        return str(cwd)
+
+
+# Two independent triggers, both conservative. Bare "that"/"this" appear
+# nowhere: "find files THAT are bigger than 100MB" is a relative clause, not a
+# follow-up, and wrongly injected history spends tokens on a model that
+# measurably degrades with prompt noise (see hostctx.py). Plural
+# demonstratives and "again" almost never occur outside a genuine follow-up,
+# so they may appear anywhere in the sentence.
+_STRONG_RE = re.compile(
+    r"\b(them|those|these|that one|this one|the same|again)\b", re.IGNORECASE)
+
+# Weak references ("it") count only under an imperative verb lead ("run it"),
+# never free-standing: "what time is it" must stay clean.
+_REF_RE = re.compile(
+    r"\b(it|them|those|these|that one|this one|the same)\b", re.IGNORECASE)
+_VERB_RE = re.compile(
+    r"^\s*(?:please\s+|can you\s+|could you\s+)?"
+    r"(run|execute|delete|remove|kill|open|rename|move|copy|repeat|redo|stop)\b",
+    re.IGNORECASE)
+
+
+def looks_anaphoric(prompt: str) -> bool:
+    """True when the request plausibly refers to a previous turn."""
+    return bool(_STRONG_RE.search(prompt)
+                or (_VERB_RE.match(prompt) and _REF_RE.search(prompt)))
+
+
+def _read_turns() -> list[dict]:
+    """Parse the file tail, skipping anything that is not a valid turn."""
+    p = _path()
+    try:
+        with open(p, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            f.seek(max(0, size - _TAIL_BYTES))
+            raw = f.read().decode("utf-8", "replace")
+    except OSError:
+        return []
+    turns = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(d, dict) and isinstance(d.get("nl"), str) \
+                and isinstance(d.get("command"), str):
+            turns.append(d)
+    return turns
+
+
+def _truncate() -> None:
+    try:
+        _path().unlink()
+    except OSError:
+        pass
+
+
+def _rewrite(turns: list[dict]) -> None:
+    """Rewrite all turns, creating owner-only (0600, O_NOFOLLOW).
+
+    Same discipline as queries.jsonl and server.token: create at 0600 rather
+    than write-then-chmod (the latter leaves a group-readable window on shared
+    NFS homes), O_NOFOLLOW so a planted symlink in a user-controlled
+    WHATISIT_DATA_DIR fails hard instead of redirecting the write, and fchmod
+    on the open fd to repair a pre-existing wrongly-permissioned file.
+    """
+    p = _path()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        os.chmod(p.parent, 0o700)
+    except OSError:
+        pass
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if os.name != "nt":
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(str(p), flags, 0o600)
+    except OSError:
+        return  # O_NOFOLLOW tripped: refuse to write through the symlink
+    try:
+        os.fchmod(fd, 0o600)
+    except (OSError, AttributeError):
+        pass  # Windows has neither meaningful chmod nor the POSIX-perm threat
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write("".join(json.dumps(t, ensure_ascii=False) + "\n" for t in turns))
+
+
+def load_valid() -> list[dict]:
+    """Turns the model may legitimately see, resetting the file otherwise.
+
+    A session is dead when its TTL lapsed or the working directory moved;
+    either way the stored context would resolve references against the wrong
+    scene. Corruption and wrong permissions reset too: a session we cannot
+    fully trust is a session we do not use.
+    """
+    turns = _read_turns()
+    fresh = False
+    if turns:
+        last = turns[-1]
+        if time.time() - float(last.get("ts", 0)) > TTL_SECONDS:
+            fresh = True
+        elif _norm_cwd(last.get("cwd")) != _norm_cwd(os.getcwd()):
+            fresh = True
+    elif _path().exists():
+        fresh = True  # exists but parsed to nothing usable
+    if os.name != "nt" and not fresh and _path().exists():
+        try:
+            if (_path().stat().st_mode & 0o777) != 0o600:
+                fresh = True
+        except OSError:
+            fresh = True
+    if fresh:
+        _truncate()
+        return []
+    return turns
+
+
+def record(nl: str, command: str) -> None:
+    """Append one turn, enforcing MAX_TURNS. The caller only ever passes a
+    non-DANGER command after successful generation (see cmd_query)."""
+    turn = {
+        "ts": time.time(),
+        "cwd": _norm_cwd(os.getcwd()),
+        "nl": nl[:MAX_NL_CHARS],
+        "command": command[:MAX_CMD_CHARS],
+        "executed": False,
+        "exit_code": None,
+    }
+    turns = (_read_turns() + [turn])[-MAX_TURNS:]
+    _rewrite(turns)
+
+
+def update_executed(command: str, exit_code: int) -> None:
+    """Overwrite the newest turn after -e runs it, recording what actually
+    executed and how it fared. No-op when nothing was recorded -- e.g. the
+    newest generation was DANGER-flagged and skipped."""
+    turns = _read_turns()
+    if not turns:
+        return
+    turns[-1]["command"] = command[:MAX_CMD_CHARS]
+    turns[-1]["executed"] = True
+    turns[-1]["exit_code"] = int(exit_code)
+    _rewrite(turns)
+
+
+def history_block(turns: list[dict]) -> str | None:
+    """The injected context, in minimal tokens: one tight line per turn."""
+    if not turns:
+        return None
+    return "\n".join(f'Prior: "{t["nl"]}" -> {t["command"]}' for t in turns)
+
+
+def clear() -> bool:
+    existed = _path().exists()
+    _truncate()
+    return existed
+
+
+def show() -> list[dict]:
+    """Raw turns for `session show`, without reset side effects."""
+    return _read_turns()


### PR DESCRIPTION
## What does this change do, and why?

Every `whatisit` run starts from nothing. That's fine for "find files bigger
than 100MB", and it falls over the moment you want to refer back to the last
answer:

```
$ whatisit list three python files in this folder
ls *.py | head -3

$ whatisit execute them
# them who? the model has never heard of a previous question
```

The README lists this under "what it gets wrong": single-turn, no memory of
your last command. This PR adds opt-in session memory that closes that gap,
without changing what ordinary requests produce.

The constraint that shaped the whole design is the one hostctx.py already
taught us: a 1.5B degrades measurably when you feed it prompt tokens it
didn't need. So history goes in surgically, not by default.

- It's **off** unless you ask for it: `--session` for one run, or
  `whatisit config --set sessions=true`.
- Even when enabled, history only reaches the prompt when `looks_anaphoric()`
  thinks the new request actually points back at something. Strong references
  ("them", "those", "again", "that one") count anywhere; bare "it" only under
  an imperative verb lead ("delete it"). Bare "that"/"this" are excluded on
  purpose — "find files THAT are bigger than 100MB" is a relative clause, not
  a follow-up.
- A request that doesn't trigger detection gets a byte-identical prompt to
  master. There's a test pinning that, because "trust me" isn't a guarantee
  you can act on.

When detection does fire, the injection is at most three tight lines:

```
Prior: "list three python files here" -> ls *.py | head -3
```

Storage is NDJSON (one turn per line), capped at three turns, read from the
file tail only — there's no document to parse and nothing to migrate. Same
privacy posture as queries.jsonl: local disk only, 0700 dir, created at 0600,
O_NOFOLLOW, fchmod repair. `whatisit session show` prints what's remembered;
`whatisit session clear` wipes it.

Two rules I'd ask you to read twice:

1. A command flagged **DANGER is never written to the store**. Otherwise
   "run it again" becomes a way to replay something the checker rejected —
   the stored history would launder the command past its own safety gate.
2. On `-e`, the stored turn is overwritten with the command that actually ran
   plus its exit code. History should reflect what happened, not an
   unexecuted guess.

Sessions also die on a 15-minute TTL, a cwd change (compared via realpath, so
`/tmp` vs `/private/tmp` doesn't count as a move), corruption, or wrong file
permissions. A session we can't fully trust is one we don't use.

Flow-specific behaviour: `-q` output never sees history, so
`eval "$(whatisit -q ...)"` stays deterministic regardless of any active
session. `-e` does see it — resolving "delete them" against the prior turn is
the entire point — and still passes through the same DANGER refusal as before.
History works with `host_context=false`; the two switches are independent.

One implementation wart, called out in comments: argparse cannot route
`session show`. The greedy `words` positional steals the literal token
"session" (the same class of problem QueryArgs exists for; stop/config dodge
it because they take no positional argument), so main() hand-routes this
subcommand.

## How was it tested?

- [x] `pytest -q` passes locally (`whatisit_pkg/`) — 395 passed, including
      45 new tests in `tests/test_sessions.py`
- [x] `ruff check .` is clean
- [x] `safety.py` / `extract.py` untouched by this PR

New coverage, briefly:

- `test_sessions.py`: NDJSON roundtrip / three-turn cap / corrupt-line
  tolerance, permission enforcement and planted-symlink refusal (POSIX-gated),
  TTL expiry, cwd resets including realpath normalization, the anaphora
  positive/negative tables, block format, `update_executed` semantics.
- `test_cli.py`: the gating truth table (default off, flag, config key, `-q`
  suppression), DANGER-not-recorded, `-e` overwrite with exit code, stale
  reset before injection, subcommand routing.
- `test_engine.py` + `test_hostctx.py`: `extra_context` forwarding on both
  server and remote paths, None-is-byte-identical regression guard, placement
  immediately before `<request>`, independence from the host-context switch.

`sessions.py` sits at 93% statement coverage; the eight missed lines are all
defensive `except OSError` fallbacks.

Honest caveat: the suite mocks generation, so the model's actual answer
quality with a Prior block in the prompt has not been measured yet — I've
exercised the CLI surface end to end but not eyeballed real follow-up answers
on a machine with the model downloaded. Detection gating means the worst case
should be today's behaviour, but that's reasoning, not measurement, and this
README's culture doesn't pretend otherwise.

Also fixed in passing, one line: `test_execute_marks_generation_as_execution_intended`
read the ambient `~/.config/whatisit/config.json`, so on any dev box with
`confirm_execute=false` the refusal it exists to pin silently never happens.
It now isolates its config dir. That failure pre-dates this branch — it
reproduces on pristine master on such a machine.

## Anything reviewers should look at closely?

1. `looks_anaphoric()` is regex heuristics, and the line between "catches
   enough follow-ups" and "stays quiet on relative clauses" is judgement.
   The positive/negative tables in test_sessions.py are the spec — if you'd
   draw that line elsewhere, those lists are where to push.
2. A wrong-permissioned `session.jsonl` is treated as compromised and reset
   rather than repaired. Repairing would be friendlier, but the file's whole
   job is being trustworthy context, so resetting felt more honest.
3. Concurrency is last-writer-wins, no lockfile. Two terminals racing can
   lose a turn; a lockfile trades that for stale-lock failure modes, which
   seemed worse for ~300 bytes of state. queries.jsonl makes the same trade.
4. The Prior block deliberately has no wrapper tags (unlike
   `<host_environment>`). Fewer tokens — but if the model turns out to treat
   it as instructions rather than context, delimiters are the first thing
   I'd try.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional session memory for follow-up requests across CLI invocations.
  * Added commands to inspect and clear stored session history.
  * Sessions retain recent context, track execution results, and automatically expire or reset when invalid.
  * Session recording excludes potentially unsafe commands and is disabled by default.

* **Documentation**
  * Documented session usage, storage, expiration, limitations, and privacy-related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->