### PR TITLE
fix(engine): stop the right process, and keep the record when it is not ours

### DIFF
--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -225,6 +225,25 @@ class TestCmdQueryQuietDangerRefusal:
         assert rc != 7
         assert "disabled" not in capsys.readouterr().err
 
+# -------------------------------------------------------------------- stop
+
+class TestCmdStop:
+    @pytest.mark.parametrize("verdict,rc,needle,stream", [
+        (True,  0, "server stopped",    "out"),
+        (False, 0, "no server running", "out"),
+        (None,  1, "left it alone",     "err"),
+    ])
+    def test_reports_each_outcome(self, monkeypatch, capsys, verdict, rc,
+                                  needle, stream):
+        # None is the case the tri-state exists for: something is running on
+        # the recorded pid and we declined to touch it. Saying "no server
+        # running" there is the opposite of the truth.
+        monkeypatch.setattr(cli.engine, "stop_server", lambda: verdict)
+        assert cli.main(["stop"]) == rc
+        cap = capsys.readouterr()
+        assert needle in (cap.out if stream == "out" else cap.err)
+
+
 # ------------------------------------------------------------------ parser
 
 class TestBuildParser:

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -1147,16 +1147,27 @@ class TestStopServerOwnership:
         sd.mkdir(parents=True)
         return sd
 
+    @pytest.mark.parametrize("gone,record_kept,verdict",
+                             [(True, False, False), (False, True, None)])
     def test_stop_server_spares_a_process_that_is_not_ours(
-            self, monkeypatch, tmp_path):
+            self, monkeypatch, tmp_path, gone, record_kept, verdict):
+        # Never ours, so never signalled. But a pid that is still alive may be
+        # ours and merely unattributable, and wiping the record then strands a
+        # resident server nothing can find. A dead pid is just a stale record.
         sd = self._isolate(monkeypatch, tmp_path)
-        (sd / "server.pid").write_text("99999\n")
+        for name in ("server.pid", "server.port", "server.params"):
+            (sd / name).write_text("99999\n")
         killed = []
         monkeypatch.setattr(engine, "_is_our_server", lambda pid: False)
+        monkeypatch.setattr(engine, "_pid_gone", lambda pid: gone)
         monkeypatch.setattr(engine.os, "kill",
                             lambda pid, sig: killed.append(sig))
-        assert engine.stop_server() is False
+        # None, not False: a live pid we could not attribute is not the same
+        # answer as nothing to stop, and cmd_stop has to say so.
+        assert engine.stop_server() is verdict
         assert killed == []
+        assert (sd / "server.pid").exists() is record_kept
+        assert (sd / "server.params").exists() is record_kept
 
     @pytest.mark.skipif(sys.platform == "win32",
                         reason="no SIGKILL on Windows; _terminate returns before it")

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -5,12 +5,17 @@ model file: engine._post / engine._query_server / engine.start_server are all
 monkeypatched, and "model" paths are just empty tmp_path files that only need
 to exist.
 """
+import json
 import os
+import signal
 import socket
 import stat
+import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
+from types import SimpleNamespace
 
 import pytest
 
@@ -1130,3 +1135,261 @@ class TestGenerateGrammarAndPostprocess:
         for flag in ("--file", "--system-prompt-file", "--grammar-file"):
             path = cmd[cmd.index(flag) + 1]
             assert not os.path.exists(path)
+
+
+# ------------------------------------------------------- stopping the server
+
+class TestStopServerOwnership:
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+        sd = tmp_path / "data" / "run"
+        sd.mkdir(parents=True)
+        return sd
+
+    def test_stop_server_spares_a_process_that_is_not_ours(
+            self, monkeypatch, tmp_path):
+        sd = self._isolate(monkeypatch, tmp_path)
+        (sd / "server.pid").write_text("99999\n")
+        killed = []
+        monkeypatch.setattr(engine, "_is_our_server", lambda pid: False)
+        monkeypatch.setattr(engine.os, "kill",
+                            lambda pid, sig: killed.append(sig))
+        assert engine.stop_server() is False
+        assert killed == []
+
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="no SIGKILL on Windows; _terminate returns before it")
+    def test_stop_server_escalates_when_sigterm_is_ignored(
+            self, monkeypatch, tmp_path):
+        # The pid record is unlinked either way, so a survivor would keep the
+        # model resident with nothing left able to find it.
+        sd = self._isolate(monkeypatch, tmp_path)
+        (sd / "server.pid").write_text("99999\n")
+        sent = []
+        monkeypatch.setattr(engine, "_is_windows", lambda: False)
+        monkeypatch.setattr(engine, "_is_our_server", lambda pid: True)
+        monkeypatch.setattr(engine, "_pid_gone", lambda pid: False)
+        monkeypatch.setattr(engine, "_STOP_WAIT", 0.0)
+        monkeypatch.setattr(engine.os, "kill",
+                            lambda pid, sig: sent.append(sig))
+        assert engine.stop_server() is False
+        assert sent == [signal.SIGTERM, signal.SIGKILL]
+
+    def test_terminate_does_not_escalate_on_windows(self, monkeypatch):
+        # TerminateProcess is already unconditional, and there is no SIGKILL
+        # to fall back to. Faked, so the branch is covered off Windows too.
+        sent = []
+        monkeypatch.setattr(engine, "_is_windows", lambda: True)
+        monkeypatch.setattr(engine.os, "kill", lambda pid, sig: sent.append(sig))
+        assert engine._terminate(4242) is True
+        assert sent == [signal.SIGTERM]
+
+    @pytest.mark.parametrize("cmdline,expected", [
+        ("/opt/l/bin/llama-server --port 8080", True),
+        ("tail -f /opt/l/bin/llama-server.log", False),
+        ("vim /opt/l/bin/llama-server.cpp", False),
+        ("", False),
+    ])
+    def test_is_our_server_needs_the_binary_as_an_argument(
+            self, monkeypatch, tmp_path, cmdline, expected):
+        # The bystander that got killed was a tail of the server's own log.
+        self._isolate(monkeypatch, tmp_path)
+        monkeypatch.setattr(engine, "_is_windows", lambda: False)
+        monkeypatch.setattr(engine, "_pid_cmdline", lambda pid: cmdline)
+        monkeypatch.setattr(engine, "_read_params",
+                            lambda: {"server_bin": "/opt/l/bin/llama-server"})
+        assert engine._is_our_server(4242) is expected
+
+    def test_params_are_recorded_when_the_server_never_becomes_ready(
+            self, monkeypatch, tmp_path):
+        # A start that times out still leaves a pid. Without the params beside
+        # it, stop_server cannot attribute that pid and falls back to a looser
+        # test, which is the state a user is in when they reach for `stop`.
+        sd = self._isolate(monkeypatch, tmp_path)
+        model, srv = tmp_path / "m.gguf", tmp_path / "llama-server"
+        model.write_bytes(b"x")
+        srv.write_bytes(b"x")
+        monkeypatch.setattr(engine.subprocess, "Popen",
+                            lambda *a, **k: SimpleNamespace(pid=4242,
+                                                            poll=lambda: None))
+        monkeypatch.setattr(engine, "_alive", lambda *a, **k: False)
+        with pytest.raises(RuntimeError):
+            engine.start_server(model, srv, threads=1, wait=0.0, quiet=True)
+        assert (sd / "server.pid").read_text().strip() == "4242"
+        assert json.loads((sd / "server.params").read_text())["server_bin"] == str(srv)
+
+    def test_legacy_state_without_params_still_rejects_a_log_path(
+            self, monkeypatch, tmp_path):
+        # Pre-0.3.1 state dirs have no server_bin. The name still has to be a
+        # whole argument, or the original bystander kill comes straight back.
+        self._isolate(monkeypatch, tmp_path)
+        monkeypatch.setattr(engine, "_is_windows", lambda: False)
+        monkeypatch.setattr(engine, "_read_params", lambda: None)
+        monkeypatch.setattr(engine, "_pid_cmdline",
+                            lambda pid: "tail -f /opt/l/llama-server.log")
+        assert engine._is_our_server(4242) is False
+        monkeypatch.setattr(engine, "_pid_cmdline",
+                            lambda pid: "/opt/l/bin/llama-server --port 8080")
+        assert engine._is_our_server(4242) is True
+
+    def test_legacy_state_matches_a_windows_image_name(
+            self, monkeypatch, tmp_path):
+        # tasklist reports `llama-server.exe`, and the loose substring test this
+        # replaces accepted it. Without the suffix we would refuse to stop a
+        # pre-upgrade Windows server, which is the only way to reach here.
+        self._isolate(monkeypatch, tmp_path)
+        monkeypatch.setattr(engine, "_is_windows", lambda: True)
+        monkeypatch.setattr(engine, "_read_params", lambda: None)
+        monkeypatch.setattr(engine, "_pid_cmdline",
+                            lambda pid: " llama-server.exe   4242 Console  1  1 612 344 K \n")
+        assert engine._is_our_server(4242) is True
+        monkeypatch.setattr(engine, "_pid_cmdline",
+                            lambda pid: " notepad.exe   4242 Console  1  9 000 K \n")
+        assert engine._is_our_server(4242) is False
+
+    def test_ps_output_is_not_rewritten(self, monkeypatch, tmp_path):
+        # The tasklist CSV normalisation must not reach ps: a comma there is
+        # part of an argument, and blanking it can forge a matching token.
+        self._isolate(monkeypatch, tmp_path)
+        out = "/usr/bin/python3 -c x --data=a,/opt/l/bin/llama-server,b"
+        monkeypatch.setattr(engine, "_is_windows", lambda: False)
+        monkeypatch.setattr(engine.subprocess, "run",
+                            lambda cmd, **k: SimpleNamespace(returncode=0, stdout=out))
+        assert engine._pid_cmdline(4242) == out
+        monkeypatch.setattr(engine, "_read_params",
+                            lambda: {"server_bin": "/opt/l/bin/llama-server"})
+        assert engine._is_our_server(4242) is False
+
+    def test_no_sigkill_once_the_pid_stopped_being_ours(
+            self, monkeypatch, tmp_path):
+        # SIGKILL cannot be caught, and the attribution is up to _STOP_WAIT old
+        # by the time it is sent.
+        self._isolate(monkeypatch, tmp_path)
+        sent = []
+        monkeypatch.setattr(engine, "_is_windows", lambda: False)
+        monkeypatch.setattr(engine, "_STOP_WAIT", 0.0)
+        monkeypatch.setattr(engine, "_pid_gone", lambda pid: False)
+        # stop_server already attributed this pid; by the re-check it is gone.
+        monkeypatch.setattr(engine, "_is_our_server", lambda pid: False)
+        monkeypatch.setattr(engine.os, "kill",
+                            lambda pid, sig: sent.append(sig))
+        assert engine._terminate(4242) is False
+        assert sent == [signal.SIGTERM]
+
+    def test_is_our_server_is_false_when_the_pid_is_gone(
+            self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        monkeypatch.setattr(engine, "_pid_cmdline", lambda pid: None)
+        assert engine._is_our_server(4242) is False
+
+    def _child(self, request):
+        """A real child process, reaped whatever the test does.
+
+        It reports readiness on stdout: until exec has happened the child's
+        command line is still a copy of this process's own.
+        """
+        proc = subprocess.Popen(
+            [sys.executable, "-c",
+             "import sys, time; sys.stdout.write('x'); sys.stdout.flush();"
+             " time.sleep(60)"],
+            stdout=subprocess.PIPE)
+
+        def cleanup():
+            proc.kill()
+            proc.wait()
+            proc.stdout.close()
+
+        request.addfinalizer(cleanup)
+        assert proc.stdout.read(1) == b"x"
+        return proc
+
+    def _recorded_bin(self, proc):
+        """The argv[0] the OS actually reports for this child.
+
+        Not sys.executable: a macOS framework python re-execs itself, so ps
+        names the framework binary, and tasklist reports an image name rather
+        than a path. start_server records the binary it launched, which is the
+        same string this reads back.
+        """
+        cmdline = engine._pid_cmdline(proc.pid)
+        assert cmdline, "the child should still be running"
+        return cmdline.split()[0]
+
+    # --- real processes: the only way the Windows branch gets exercised, and
+    # CI runs windows-latest on 3.9 and 3.13.
+
+    def test_is_our_server_recognises_a_real_child(
+            self, monkeypatch, tmp_path, request):
+        self._isolate(monkeypatch, tmp_path)
+        proc = self._child(request)
+        binary = self._recorded_bin(proc)
+        monkeypatch.setattr(engine, "_read_params",
+                            lambda: {"server_bin": binary})
+        assert engine._is_our_server(proc.pid) is True
+
+    def test_is_our_server_rejects_a_real_unrelated_process(
+            self, monkeypatch, tmp_path, request):
+        self._isolate(monkeypatch, tmp_path)
+        proc = self._child(request)
+        monkeypatch.setattr(engine, "_read_params",
+                            lambda: {"server_bin": "/nowhere/llama-server"})
+        assert engine._is_our_server(proc.pid) is False
+
+    def test_is_our_server_is_false_for_a_pid_that_is_gone(
+            self, monkeypatch, tmp_path, request):
+        self._isolate(monkeypatch, tmp_path)
+        proc = self._child(request)
+        pid = proc.pid
+        proc.kill()
+        proc.wait()
+        monkeypatch.setattr(engine, "_read_params",
+                            lambda: {"server_bin": sys.executable})
+        assert engine._is_our_server(pid) is False
+
+    def test_terminate_actually_kills_a_real_process(
+            self, monkeypatch, tmp_path, request):
+        self._isolate(monkeypatch, tmp_path)
+        proc = self._child(request)
+        began = time.time()
+        assert engine._terminate(proc.pid) is True
+        # A process that takes SIGTERM must not cost the escalation window.
+        assert time.time() - began < 0.5
+        assert proc.wait(timeout=10) is not None
+
+    def test_stop_server_kills_a_real_child_end_to_end(
+            self, monkeypatch, tmp_path, request):
+        sd = self._isolate(monkeypatch, tmp_path)
+        proc = self._child(request)
+        (sd / "server.pid").write_text(f"{proc.pid}\n")
+        (sd / "server.params").write_text(
+            json.dumps({"server_bin": self._recorded_bin(proc)}))
+        assert engine.stop_server() is True
+        assert proc.wait(timeout=10) is not None
+        assert not (sd / "server.pid").exists()
+
+    def test_windows_ownership_reads_tasklist_output(self, monkeypatch, tmp_path):
+        # Pinned against a recorded sample so the CSV shape is checked on every
+        # platform, not only when CI happens to be on Windows.
+        self._isolate(monkeypatch, tmp_path)
+        sample = '"llama-server.exe","4242","Console","1","1,612,344 K"\n'
+        argv = []
+        monkeypatch.setattr(engine, "_is_windows", lambda: True)
+        monkeypatch.setattr(engine.subprocess, "run",
+                            lambda cmd, **k: (argv.append(cmd),
+                                              SimpleNamespace(returncode=0,
+                                                              stdout=sample))[1])
+        monkeypatch.setattr(engine, "_read_params",
+                            lambda: {"server_bin": "C:\\llama\\llama-server.exe"})
+        assert engine._is_our_server(4242) is True
+        assert argv[0][0] == "tasklist" and "PID eq 4242" in argv[0]
+        monkeypatch.setattr(engine, "_read_params",
+                            lambda: {"server_bin": "C:\\llama\\other.exe"})
+        assert engine._is_our_server(4242) is False
+
+    def test_pid_gone_never_signals_on_windows(self, monkeypatch):
+        # os.kill(pid, 0) calls TerminateProcess there, so it must not run.
+        monkeypatch.setattr(engine, "_is_windows", lambda: True)
+        monkeypatch.setattr(engine.os, "kill",
+                            lambda *a: pytest.fail("os.kill reached on Windows"))
+        assert engine._pid_gone(4242) is False

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -672,7 +672,12 @@ def cmd_doctor(args, cfg: dict) -> int:
 
 
 def cmd_stop(args, cfg: dict) -> int:
-    print("whatisit: server stopped." if engine.stop_server() else "whatisit: no server running.")
+    stopped = engine.stop_server()
+    if stopped is None:
+        warn("whatisit: a server is running on the recorded pid but could not be "
+             "identified as ours; left it alone.")
+        return 1
+    out("whatisit: server stopped." if stopped else "whatisit: no server running.")
     return 0
 
 

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -545,7 +545,12 @@ def _terminate(pid: int) -> bool:
     return _pid_gone(pid)
 
 
-def stop_server() -> bool:
+def stop_server() -> bool | None:
+    """True stopped it, False nothing to stop, None left a live one alone.
+
+    None is the case where a process holds the recorded pid but cannot be
+    attributed to us, so signalling it would be a guess. The record is kept.
+    """
     pid_f = _state_dir() / "server.pid"
     stopped = False
     if pid_f.exists():
@@ -553,6 +558,14 @@ def stop_server() -> bool:
             pid = int(pid_f.read_text().strip())
             if _is_our_server(pid):
                 stopped = _terminate(pid)
+            elif not _pid_gone(pid):
+                # Alive but not attributable. Wiping the record here strands a
+                # resident server that nothing can find again. A stale record
+                # is the recoverable direction: start_server overwrites it.
+                # _pid_gone is unconditionally False on Windows, so there this
+                # branch also catches pids that are genuinely gone and no stop
+                # ever clears the record; the next start_server does.
+                return None
         except (ValueError, OSError):
             pass
         pid_f.unlink(missing_ok=True)

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -44,6 +44,7 @@ from .extract import extract
 HOST = "127.0.0.1"
 STOP = ["\n", "<|im_end|>", "```"]
 _OWNER_WAIT_MAX = 2.0
+_STOP_WAIT = 2.0        # seconds to let SIGTERM land before SIGKILL
 _TCP_INSPECTION_ERROR = (
     "TCP transport requires /proc or lsof to attribute the server connection; "
     "use the UNIX socket transport instead"
@@ -433,6 +434,37 @@ def running_port() -> int | None:
         return None
 
 
+def _is_windows() -> bool:
+    """Isolated so tests can fake Windows without rewriting global os.name.
+
+    Same reason as cli._is_windows: on Python 3.11 and older, os.name="nt"
+    makes pathlib hand back a WindowsPath, and instantiating one off Windows
+    raises NotImplementedError.
+    """
+    return os.name == "nt"
+
+
+def _pid_cmdline(pid: int) -> str | None:
+    """The command line of one already-known pid, or None if it is gone."""
+    try:
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+        return raw.replace(b"\x00", b" ").decode(errors="replace")
+    except OSError:
+        pass
+    # No /proc: macOS has ps, Windows tasklist. argv is passed without a shell.
+    cmd = (["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"]
+           if _is_windows() else ["ps", "-p", str(pid), "-o", "command="])
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=1.0)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if p.returncode != 0:
+        return None
+    # tasklist quotes every field and groups digits in the memory column; ps
+    # output must not be rewritten, a comma there is part of an argument.
+    return p.stdout.replace('"', " ").replace(",", " ") if _is_windows() else p.stdout
+
+
 def _is_our_server(pid: int) -> bool:
     """Confirm a pid really is our llama-server before signalling it.
 
@@ -440,21 +472,77 @@ def _is_our_server(pid: int) -> bool:
     pid. On a long-lived shared node that is somebody's -- possibly your own --
     unrelated process.
     """
+    cmdline = _pid_cmdline(pid)
+    if cmdline is None:
+        return False
+    binary = (_read_params() or {}).get("server_bin")
+    if not binary:
+        # Started before this version recorded params. Still require the name
+        # as a whole argument, so a log path cannot pass; tasklist reports the
+        # image name, hence the suffix.
+        return any(t.replace("\\", "/").rsplit("/", 1)[-1].removesuffix(".exe")
+                   == "llama-server" for t in cmdline.split())
+    # An exact argument, not a substring: `tail -f .../llama-server.log` names
+    # the path too. tasklist reports the image name only, hence the basename.
+    want = binary.replace("\\", "/").rsplit("/", 1)[-1] if _is_windows() else binary
+    return want in cmdline.split()
+
+
+def _pid_gone(pid: int) -> bool:
+    if _is_windows():
+        return False             # os.kill(pid, 0) TERMINATES on Windows
     try:
-        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
-        cmdline = raw.replace(b"\x00", b" ").decode(errors="replace")
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
     except OSError:
-        # macOS has no /proc. ps is used only to inspect one already-known pid;
-        # argument vectors are still passed without a shell.
-        try:
-            p = subprocess.run(["ps", "-p", str(pid), "-o", "command="],
-                               capture_output=True, text=True, timeout=1.0)
-            if p.returncode != 0:
-                return False
-            cmdline = p.stdout
-        except (OSError, subprocess.TimeoutExpired):
-            return False
-    return "llama-server" in cmdline
+        return False             # EPERM: not ours to signal, but alive
+    return False
+
+
+def _reap(pid: int) -> None:
+    """Clear the zombie if this server happens to be our own child.
+
+    A dead-but-unreaped process still answers signal 0, so without this the
+    escalation below would never see it exit.
+    """
+    try:
+        os.waitpid(pid, os.WNOHANG)
+    except (OSError, AttributeError, ValueError):
+        pass
+
+
+def _terminate(pid: int) -> bool:
+    """SIGTERM, then SIGKILL if it is still there.
+
+    stop_server drops the only record of this pid right after, so a server
+    that ignored SIGTERM would hold the model with nothing left to find it.
+    """
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        return False
+    if _is_windows():
+        return True              # TerminateProcess; nothing to escalate to
+    deadline = time.monotonic() + _STOP_WAIT
+    while True:
+        _reap(pid)
+        if _pid_gone(pid):
+            return True
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(0.05)
+    # The pid was last attributed up to _STOP_WAIT ago and SIGKILL cannot be
+    # caught, so confirm it is still ours before sending it.
+    if not _is_our_server(pid):
+        return False
+    try:
+        os.kill(pid, signal.SIGKILL)
+        time.sleep(0.05)
+    except OSError:
+        pass
+    _reap(pid)
+    return _pid_gone(pid)
 
 
 def stop_server() -> bool:
@@ -464,9 +552,8 @@ def stop_server() -> bool:
         try:
             pid = int(pid_f.read_text().strip())
             if _is_our_server(pid):
-                os.kill(pid, signal.SIGTERM)
-                stopped = True
-        except (ProcessLookupError, ValueError, PermissionError):
+                stopped = _terminate(pid)
+        except (ValueError, OSError):
             pass
         pid_f.unlink(missing_ok=True)
     _port_file().unlink(missing_ok=True)
@@ -561,6 +648,9 @@ def start_server(model: Path, server_bin: Path, threads: int,
         proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, stdin=subprocess.DEVNULL,
                                 env=launch_env, start_new_session=True)
     _write_private(sd / "server.pid", str(proc.pid))
+    # Beside the pid, not after the readiness wait: a start that times out or
+    # dies still leaves a pid that stop_server has to be able to attribute.
+    _write_private(_params_file(), json.dumps(requested))
     if port:
         _write_private(_port_file(), str(port))
 
@@ -574,7 +664,6 @@ def start_server(model: Path, server_bin: Path, threads: int,
         if _alive(port or None, expected_pid=proc.pid if port else None):
             if not quiet:
                 print(" ready.", file=sys.stderr, flush=True)
-            _write_private(_params_file(), json.dumps(requested))
             return port
         time.sleep(0.3)
     raise RuntimeError(f"llama-server did not become ready in {wait:.0f}s; see {log}")


### PR DESCRIPTION
Three bugs in `whatisit stop`.

**It could kill an unrelated process.** Ownership was decided by looking for the
string `llama-server` anywhere in a process's command line, so something like
`tail -f /var/log/llama-server.log` matched and got terminated. It now requires
the recorded server binary to appear as an actual argument.

**It could leave a server running but unreachable.** `stop` sent SIGTERM without
waiting, then immediately deleted the file recording which process to talk to. A
server that ignored the signal kept the model in memory with nothing able to
find it again. It now waits, confirms, and escalates if needed.

**It reported success when it had done nothing.** If the recorded process could
not be identified, `stop` wiped the record anyway and printed "server stopped."
It now leaves the record in place and says what actually happened.

Also writes the server's parameters at launch rather than after startup
completes, so a server that fails to start is still identifiable afterwards.

Stacked on #50.