### PR TITLE
feat(engine): unload the resident model at N idle seconds (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ whatisit -e remove every .pyc file under this tree
 `whatisit stop` shuts down the resident model server. `whatisit config --set threads=4`
 changes settings.
 
+### Unloading the model automatically
+
+The resident server keeps the model in RAM so answers are instant. On a
+memory-constrained box you can have it unload itself after a period of
+inactivity instead of keeping that RAM forever:
+
+```bash
+whatisit --idle-timeout 300 show disk usage   # this invocation only
+whatisit config --set idle_timeout=300        # persist it (0 = never, default)
+```
+
+After 300 idle seconds a small watchdog process stops the server and frees the
+~1.6 GB it was holding. The next query simply starts fresh (cold start is a few
+seconds). The timeout is re-armed on every query, and an inference already in
+flight is never interrupted.
+
+Note: whatisit never uses llama-server's own `--sleep-idle-seconds` flag — in
+llama.cpp builds b7492–b9060 it triggers CVE-2026-43632 (use-after-free,
+remotely exploitable). The watchdog is plain user-space Python that watches a
+timestamp file and sends SIGTERM; nothing about it touches the server's HTTP
+surface.
+
 ## Remote endpoints
 
 To use a hosted API, Ollama, or a `llama.cpp` server you already have running:

--- a/README.md
+++ b/README.md
@@ -125,25 +125,17 @@ changes settings.
 
 ### Unloading the model automatically
 
-The resident server keeps the model in RAM so answers are instant. On a
-memory-constrained box you can have it unload itself after a period of
-inactivity instead of keeping that RAM forever:
+The resident server holds the model in RAM. On a tight box, have it unload
+itself once it has been idle for a while:
 
 ```bash
 whatisit --idle-timeout 300 show disk usage   # this invocation only
 whatisit config --set idle_timeout=300        # persist it (0 = never, default)
 ```
 
-After 300 idle seconds a small watchdog process stops the server and frees the
-~1.6 GB it was holding. The next query simply starts fresh (cold start is a few
-seconds). The timeout is re-armed on every query, and an inference already in
-flight is never interrupted.
-
-Note: whatisit never uses llama-server's own `--sleep-idle-seconds` flag — in
-llama.cpp builds b7492–b9060 it triggers CVE-2026-43632 (use-after-free,
-remotely exploitable). The watchdog is plain user-space Python that watches a
-timestamp file and sends SIGTERM; nothing about it touches the server's HTTP
-surface.
+A watchdog stops the server at the deadline and frees the memory it was
+holding; the next query pays a cold start. The deadline is re-armed on every
+query, including one still running.
 
 ## Remote endpoints
 

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -495,3 +495,76 @@ class TestQueryFlagsApply:
         assert "--debug" in err
         assert "grammar-blob" in err
         assert "list files" in err
+
+
+
+
+# ------------------------------------------------------- --idle-timeout (#42)
+
+class TestIdleTimeoutFlag:
+    """Per-invocation idle-unload deadline, following the --port/--threads
+    value-flag pattern. The feature is the user-space watchdog; llama-server's
+    own --sleep-idle-seconds (the CVE-2026-43632 trigger) never appears."""
+
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+
+    def test_flag_parses(self):
+        a = cli.QueryArgs(["--idle-timeout", "300", "list", "files"])
+        assert a.idle_timeout == 300
+        assert a.words == ["list", "files"]
+
+    def test_defaults_to_none_when_absent(self):
+        assert cli.QueryArgs(["list", "files"]).idle_timeout is None
+
+    def test_missing_value_raises(self):
+        with pytest.raises(ValueError, match="needs a value"):
+            cli.QueryArgs(["--idle-timeout"])
+
+    def test_negative_rejected_zero_accepted(self):
+        with pytest.raises(ValueError, match="must be >= 0"):
+            cli.QueryArgs(["--idle-timeout", "-1", "list", "files"])
+        assert cli.QueryArgs(["--idle-timeout", "0",
+                              "list", "files"]).idle_timeout == 0
+
+    def test_stray_flag_is_reported_not_applied(self):
+        # After the request text starts, the flag belongs to the question.
+        a = cli.QueryArgs(["list", "files", "--idle-timeout", "300"])
+        assert a.idle_timeout is None
+        assert a.stray_flags == ["--idle-timeout"]
+
+    def _capture_generate(self, monkeypatch, seen):
+        monkeypatch.setattr(cli.engine, "generate",
+                            lambda prompt, cfg, **k:
+                                seen.update(cfg=dict(cfg))
+                                or (["ls"], 0.01, "server"))
+
+    def test_override_reaches_cmd_query(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        seen = {}
+        self._capture_generate(monkeypatch, seen)
+        assert cli.main(["--idle-timeout", "123", "list", "files"]) == 0
+        assert seen["cfg"]["idle_timeout"] == 123
+
+    def test_absent_leaves_default_and_zero_overrides_saved(
+            self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        seen = {}
+        self._capture_generate(monkeypatch, seen)
+        assert cli.main(["list", "files"]) == 0
+        assert seen["cfg"]["idle_timeout"] == 0      # DEFAULTS: never unload
+        cli.main(["config", "--set", "idle_timeout=300"])
+        cap = {}
+        monkeypatch.setattr(cli.engine, "generate",
+                            lambda prompt, cfg, **k:
+                                cap.update(cfg=dict(cfg))
+                                or (["ls"], 0.01, "server"))
+        assert cli.main(["list", "files"]) == 0
+        assert cap["cfg"]["idle_timeout"] == 300     # persisted value wins
+        assert cli.main(["--idle-timeout", "0", "list", "files"]) == 0
+        assert cap["cfg"]["idle_timeout"] == 0       # explicit zero beats it
+        # Per-invocation overrides must NOT reach config.json (cmd_query's
+        # documented contract); the saved 300 has to survive untouched.
+        from whatisit import config as cfg_mod
+        assert cfg_mod.load_config()["idle_timeout"] == 300

--- a/whatisit_pkg/tests/test_cli.py
+++ b/whatisit_pkg/tests/test_cli.py
@@ -497,14 +497,12 @@ class TestQueryFlagsApply:
         assert "list files" in err
 
 
-
-
 # ------------------------------------------------------- --idle-timeout (#42)
 
 class TestIdleTimeoutFlag:
     """Per-invocation idle-unload deadline, following the --port/--threads
     value-flag pattern. The feature is the user-space watchdog; llama-server's
-    own --sleep-idle-seconds (the CVE-2026-43632 trigger) never appears."""
+    own --sleep-idle-seconds (the CVE-2026-43631 trigger) never appears."""
 
     def _isolate(self, monkeypatch, tmp_path):
         monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -1370,6 +1370,34 @@ class TestStopServerOwnership:
         assert time.time() - began < 0.5
         assert proc.wait(timeout=10) is not None
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="no SIGKILL, and SIG_IGN for SIGTERM is not honoured")
+    def test_terminate_reaps_the_zombie_it_creates(
+            self, monkeypatch, tmp_path, request):
+        # A SIGKILLed child is a zombie until it is reaped, and a zombie still
+        # answers signal 0. Without the reap after SIGKILL, _terminate reports
+        # failure for a server it just killed and `stop` says none was running.
+        self._isolate(monkeypatch, tmp_path)
+        proc = subprocess.Popen(
+            [sys.executable, "-c",
+             "import signal, sys, time;"
+             " signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+             " sys.stdout.write('x'); sys.stdout.flush(); time.sleep(60)"],
+            stdout=subprocess.PIPE)
+
+        def cleanup():
+            proc.kill()
+            proc.wait()
+            proc.stdout.close()
+
+        request.addfinalizer(cleanup)
+        assert proc.stdout.read(1) == b"x"
+        monkeypatch.setattr(engine, "_read_params",
+                            lambda: {"server_bin": self._recorded_bin(proc)})
+        monkeypatch.setattr(engine, "_STOP_WAIT", 0.3)
+        assert engine._terminate(proc.pid) is True
+        assert proc.wait(timeout=10) is not None
+
     def test_stop_server_kills_a_real_child_end_to_end(
             self, monkeypatch, tmp_path, request):
         sd = self._isolate(monkeypatch, tmp_path)
@@ -1408,12 +1436,12 @@ class TestStopServerOwnership:
         assert engine._pid_gone(4242) is False
 
 
-# --------------------------------------------------- idle watchdog (#42)
+# ------------------------------------------------------------ idle timeout
 
 class TestIdleTimeout:
     """--idle-timeout: the user-space watchdog unloads the resident
     llama-server at N idle seconds. llama-server's own --sleep-idle-seconds
-    (the CVE-2026-43632 trigger) is never passed -- pinned by a launch-argv
+    (the CVE-2026-43631 trigger) is never passed -- pinned by a launch-argv
     guard below."""
 
     def _isolate(self, monkeypatch, tmp_path):
@@ -1471,6 +1499,14 @@ class TestIdleTimeout:
         for name in ("server.pid", "server.watch", "server.last_use"):
             assert not (sd / name).exists()
 
+    def test_idle_stop_returns_a_bool_when_the_server_is_left_alone(
+            self, monkeypatch, tmp_path):
+        # stop_server is tri-state now; idle_stop's own contract is not.
+        sd = self._isolate(monkeypatch, tmp_path)
+        self._seed_running(sd, age=400.0, timeout=300)
+        monkeypatch.setattr(engine, "stop_server", lambda: None)
+        assert engine.idle_stop(300) is False
+
     @pytest.mark.parametrize("content", [
         "fresh",                       # built at test time, inside the window
         None,                          # missing file
@@ -1504,10 +1540,24 @@ class TestIdleTimeout:
         assert engine.stop_server() is True
         for name in names:
             assert not (sd / name).exists(), name
+    def test_spawn_watchdog_runs_outside_the_caller_cwd(
+            self, monkeypatch, tmp_path):
+        # -m puts cwd first on sys.path, so a whatisit/ package in whatever
+        # directory the user happens to be in would be imported instead.
+        sd = self._isolate(monkeypatch, tmp_path)
+        seen = {}
+
+        def fake_popen(argv, **kw):
+            seen["argv"], seen["cwd"] = argv, kw.get("cwd")
+
+        monkeypatch.setattr(engine.subprocess, "Popen", fake_popen)
+        engine._spawn_watchdog()
+        assert seen["argv"][1:] == ["-m", "whatisit.watchdog"]
+        assert seen["cwd"] == str(sd)
 
     def test_launch_cmd_never_carries_an_idle_or_sleep_flag(
             self, monkeypatch, tmp_path):
-        # THE regression guard for CVE-2026-43632: whatever else changes,
+        # THE regression guard for CVE-2026-43631: whatever else changes,
         # llama-server must never see --sleep-idle-seconds or any idle flag.
         model = tmp_path / "model.gguf"
         server = tmp_path / "llama-server"

--- a/whatisit_pkg/tests/test_engine.py
+++ b/whatisit_pkg/tests/test_engine.py
@@ -6,12 +6,14 @@ monkeypatched, and "model" paths are just empty tmp_path files that only need
 to exist.
 """
 import json
+import math
 import os
 import signal
 import socket
 import stat
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -1404,3 +1406,312 @@ class TestStopServerOwnership:
         monkeypatch.setattr(engine.os, "kill",
                             lambda *a: pytest.fail("os.kill reached on Windows"))
         assert engine._pid_gone(4242) is False
+
+
+# --------------------------------------------------- idle watchdog (#42)
+
+class TestIdleTimeout:
+    """--idle-timeout: the user-space watchdog unloads the resident
+    llama-server at N idle seconds. llama-server's own --sleep-idle-seconds
+    (the CVE-2026-43632 trigger) is never passed -- pinned by a launch-argv
+    guard below."""
+
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("WHATISIT_CONFIG_DIR", str(tmp_path / "cfg"))
+        monkeypatch.setenv("WHATISIT_DATA_DIR", str(tmp_path / "data"))
+        sd = tmp_path / "data" / "run"
+        sd.mkdir(parents=True)
+        return sd
+
+    def _seed_running(self, sd, *, timeout=300, age=400.0):
+        (sd / "server.pid").write_text("99999\n")
+        (sd / "server.watch").write_text(f"{timeout}\n")
+        if age is not None:
+            (sd / "server.last_use").write_text(f"{time.time() - age:.6f}\n")
+
+    @pytest.mark.parametrize("raw,want", [
+        (None, None), (0, None), (-3, None), ("tomorrow", None), ([], None),
+        (300, 300), ("300", 300),
+    ])
+    def test_coerce_idle_timeout(self, raw, want):
+        assert engine._coerce_idle_timeout(raw) == want
+
+    def test_touch_last_use_only_when_enabled(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        engine.touch_last_use(0)
+        engine.touch_last_use("tomorrow")
+        engine.touch_last_use(None)
+        assert not engine._last_use_path().exists()
+        engine.touch_last_use(300)
+        # nan would silently disarm every deadline; must never be written.
+        assert math.isfinite(float(engine._last_use_path().read_text()))
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod is a no-op on Windows")
+    def test_touch_writes_private_timestamp(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        engine.touch_last_use(300)
+        assert stat.S_IMODE(os.stat(engine._last_use_path()).st_mode) == 0o600
+
+    def test_idle_stop_disabled_is_a_noop(self, monkeypatch, tmp_path):
+        sd = self._isolate(monkeypatch, tmp_path)
+        self._seed_running(sd)
+        assert engine.idle_stop(0) is False
+        assert engine.idle_stop("garbage") is False
+        assert (sd / "server.pid").exists()
+
+    def test_idle_stop_fires_when_stale_and_running(self, monkeypatch, tmp_path):
+        sd = self._isolate(monkeypatch, tmp_path)
+        self._seed_running(sd, age=400.0, timeout=300)
+        killed = []
+        monkeypatch.setattr(engine, "_is_our_server", lambda pid: True)
+        monkeypatch.setattr(engine, "_pid_gone", lambda pid: True)
+        monkeypatch.setattr(engine.os, "kill",
+                            lambda pid, sig: killed.append((pid, sig)))
+        assert engine.idle_stop(300) is True
+        assert killed == [(99999, signal.SIGTERM)]
+        for name in ("server.pid", "server.watch", "server.last_use"):
+            assert not (sd / name).exists()
+
+    @pytest.mark.parametrize("content", [
+        "fresh",                       # built at test time, inside the window
+        None,                          # missing file
+        "junk\n", "nan\n", "inf\n",    # corrupt / non-finite
+    ])
+    def test_idle_stop_ignores_fresh_missing_and_corrupt(
+            self, monkeypatch, tmp_path, content):
+        sd = self._isolate(monkeypatch, tmp_path)
+        killed = []
+        monkeypatch.setattr(engine, "_is_our_server", lambda pid: True)
+        monkeypatch.setattr(engine.os, "kill",
+                            lambda pid, sig: killed.append(sig))
+        self._seed_running(sd)
+        if content is None:
+            engine._last_use_path().unlink(missing_ok=True)
+        else:
+            stamp = f"{time.time() - 5:.6f}\n" if content == "fresh" else content
+            engine._last_use_path().write_text(stamp)
+        assert engine.idle_stop(300) is False
+        assert killed == []
+
+    def test_stop_server_clears_watchdog_state(self, monkeypatch, tmp_path):
+        sd = self._isolate(monkeypatch, tmp_path)
+        names = ("server.pid", "server.port", "server.sock", "server.token",
+                 "server.params", "server.last_use", "server.watch")
+        for name in names:
+            (sd / name).write_text("99999\n" if name == "server.pid" else "x\n")
+        monkeypatch.setattr(engine, "_is_our_server", lambda pid: True)
+        monkeypatch.setattr(engine, "_pid_gone", lambda pid: True)
+        monkeypatch.setattr(engine.os, "kill", lambda pid, sig: None)
+        assert engine.stop_server() is True
+        for name in names:
+            assert not (sd / name).exists(), name
+
+    def test_launch_cmd_never_carries_an_idle_or_sleep_flag(
+            self, monkeypatch, tmp_path):
+        # THE regression guard for CVE-2026-43632: whatever else changes,
+        # llama-server must never see --sleep-idle-seconds or any idle flag.
+        model = tmp_path / "model.gguf"
+        server = tmp_path / "llama-server"
+        model.write_bytes(b"model")
+        server.write_bytes(b"binary")
+        sd = self._isolate(monkeypatch, tmp_path)
+        # Socket transport: forcing TCP would demand /proc or lsof BEFORE
+        # readiness even starts, which does not exist on Windows CI.
+        monkeypatch.setattr(engine, "running_port", lambda: None)
+
+        captured = {}
+
+        class Process:
+            pid = 2468
+            returncode = None
+
+            @staticmethod
+            def poll():
+                return None
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            return Process()
+
+        monkeypatch.setattr(engine.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(engine, "_alive", lambda *a, **k: False)
+        with pytest.raises(RuntimeError, match="did not become ready"):
+            engine.start_server(model, server, threads=2, wait=0.05,
+                                quiet=True)
+
+        cmd = captured["cmd"]
+        assert "--sleep-idle-seconds" not in cmd
+        # Scope to flag-shaped args: the model/bin paths are caller-supplied
+        # tmp_path strings and may legitimately contain any substring.
+        flags = [a for a in cmd if isinstance(a, str) and a.startswith("-")]
+        assert not any("sleep" in f.lower() or "idle" in f.lower()
+                       for f in flags), cmd
+        # The launch itself stays untouched by the feature.
+        assert not (sd / "server.watch").exists()
+        assert not (sd / "server.last_use").exists()
+
+    def _generate_env(self, monkeypatch, tmp_path):
+        model = tmp_path / "model.gguf"
+        model.write_bytes(b"model")
+        sd = self._isolate(monkeypatch, tmp_path)
+        monkeypatch.setenv("WHATISIT_MODEL", str(model))
+        monkeypatch.setenv("WHATISIT_LLAMA_SERVER", str(model))  # exists == bin
+        return sd
+
+    def test_generate_wires_the_watchdog_in_order(self, monkeypatch, tmp_path):
+        sd = self._generate_env(monkeypatch, tmp_path)
+        order = []
+        real_touch = engine.touch_last_use
+
+        def spy_touch(v):
+            order.append("touch")
+            return real_touch(v)
+
+        def fake_start(*a, **k):
+            order.append("start")
+            return 8080
+
+        def spy_query(*a, **k):
+            order.append("query")
+            return [("echo hi", None)]
+
+        monkeypatch.setattr(engine.hostctx, "build",
+                            lambda p, enabled=True, include_volatile=True:
+                            ("SYS", p))
+        monkeypatch.setattr(engine.cfg_mod, "resolve_threads", lambda cfg: 2)
+        monkeypatch.setattr(engine, "idle_stop",
+                            lambda v: order.append("lazy") or False)
+        monkeypatch.setattr(engine, "start_server", fake_start)
+        monkeypatch.setattr(engine, "touch_last_use", spy_touch)
+        monkeypatch.setattr(engine, "_query_server", spy_query)
+        monkeypatch.setattr(engine, "_spawn_watchdog",
+                            lambda: order.append("spawn"))
+
+        cmds, _, mode = engine.generate("list files",
+                                        {"idle_timeout": 300,
+                                         "host_context": False})
+        assert mode == "server" and cmds == ["echo hi"]
+        # Lazy check first, start, pre-touch BEFORE the query (a long
+        # inference must not look idle), spawn, then post-touch on success.
+        assert order == ["lazy", "start", "touch", "spawn", "query", "touch"]
+        assert (sd / "server.watch").read_text() == "300\n"
+
+    def test_heartbeat_covers_an_inference_longer_than_the_deadline(
+            self, monkeypatch, tmp_path):
+        # CodeRabbit Major on this PR: pre/post touches alone let an
+        # inference OUTLIVING idle_timeout look idle -- a 45 s generation
+        # under --idle-timeout 30 would be killed at t=30. While the query
+        # blocks, the heartbeat must keep re-arming server.last_use.
+        self._generate_env(monkeypatch, tmp_path)
+        monkeypatch.setattr(engine.hostctx, "build",
+                            lambda p, enabled=True, include_volatile=True:
+                            ("SYS", p))
+        monkeypatch.setattr(engine.cfg_mod, "resolve_threads", lambda cfg: 2)
+        monkeypatch.setattr(engine, "idle_stop", lambda v: False)
+        monkeypatch.setattr(engine, "start_server", lambda *a, **k: 8080)
+        monkeypatch.setattr(engine, "_spawn_watchdog", lambda: None)
+
+        seen = {}
+
+        def slow_query(*a, **k):
+            first = float(engine._last_use_path().read_text())
+            # Block past one beat interval, watching for a refresh.
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                if float(engine._last_use_path().read_text()) - first > 0.05:
+                    break
+                time.sleep(0.01)
+            seen["refreshed"] = \
+                float(engine._last_use_path().read_text()) - first > 0.05
+            return [("echo hi", None)]
+
+        monkeypatch.setattr(engine, "_query_server", slow_query)
+        cmds, _, mode = engine.generate("list files",
+                                        {"idle_timeout": 1,
+                                         "host_context": False})
+        assert mode == "server" and cmds == ["echo hi"]
+        assert seen["refreshed"] is True
+
+    def test_no_heartbeat_thread_when_disabled(self, monkeypatch, tmp_path):
+        self._generate_env(monkeypatch, tmp_path)
+        threads_before = threading.active_count()
+        monkeypatch.setattr(engine.hostctx, "build",
+                            lambda p, enabled=True, include_volatile=True:
+                            ("SYS", p))
+        monkeypatch.setattr(engine.cfg_mod, "resolve_threads", lambda cfg: 2)
+        monkeypatch.setattr(engine, "start_server", lambda *a, **k: 8080)
+        monkeypatch.setattr(engine, "_query_server",
+                            lambda *a, **k: [("echo hi", None)])
+        engine.generate("list files", {"idle_timeout": 0,
+                                       "host_context": False})
+        assert threading.active_count() == threads_before
+
+    def test_generate_disabled_retracts_a_live_watchdog(
+            self, monkeypatch, tmp_path):
+        sd = self._generate_env(monkeypatch, tmp_path)
+        # A previous --idle-timeout window left instructions behind.
+        (sd / "server.watch").write_text("300\n")
+        (sd / "server.last_use").write_text(f"{time.time():.6f}\n")
+        spawned = []
+        monkeypatch.setattr(engine.hostctx, "build",
+                            lambda p, enabled=True, include_volatile=True:
+                            ("SYS", p))
+        monkeypatch.setattr(engine.cfg_mod, "resolve_threads", lambda cfg: 2)
+        monkeypatch.setattr(engine, "start_server", lambda *a, **k: 8080)
+        monkeypatch.setattr(engine, "_query_server",
+                            lambda *a, **k: [("echo hi", None)])
+        monkeypatch.setattr(engine, "_spawn_watchdog",
+                            lambda: spawned.append(1))
+        engine.generate("list files", {"idle_timeout": 0,
+                                       "host_context": False})
+        assert spawned == []
+        assert not (sd / "server.watch").exists()
+        assert not (sd / "server.last_use").exists()
+
+    def test_generate_oneshot_never_touches_or_spawns(self, monkeypatch,
+                                                      tmp_path):
+        sd = self._generate_env(monkeypatch, tmp_path)
+        cli_bin = tmp_path / "llama-cli"
+        cli_bin.write_bytes(b"cli")
+        monkeypatch.delenv("WHATISIT_LLAMA_SERVER")
+        monkeypatch.setattr(engine.cfg_mod, "find_llama_cli",
+                            lambda: cli_bin)
+        monkeypatch.setattr(engine, "_query_oneshot",
+                            lambda *a, **k: [("echo hi", None)])
+        spawned = []
+        monkeypatch.setattr(engine, "_spawn_watchdog",
+                            lambda: spawned.append(1))
+        engine.generate("list files", {"idle_timeout": 300,
+                                       "host_context": False},
+                        force_oneshot=True)
+        assert spawned == []
+        assert not (sd / "server.watch").exists()
+        assert not (sd / "server.last_use").exists()
+
+    def test_spawn_failure_still_unloads_via_lazy_fallback(
+            self, monkeypatch, tmp_path):
+        # No fork available: the query must still succeed, and an already-
+        # stale server must still have been unloaded by the lazy check.
+        sd = self._generate_env(monkeypatch, tmp_path)
+        self._seed_running(sd, age=99999.0, timeout=300)
+        killed = []
+        monkeypatch.setattr(engine, "_is_our_server", lambda pid: True)
+        monkeypatch.setattr(engine, "_pid_gone", lambda pid: True)
+        monkeypatch.setattr(engine.os, "kill",
+                            lambda pid, sig: killed.append(sig))
+        monkeypatch.setattr(engine.hostctx, "build",
+                            lambda p, enabled=True, include_volatile=True:
+                            ("SYS", p))
+        monkeypatch.setattr(engine.cfg_mod, "resolve_threads", lambda cfg: 2)
+        monkeypatch.setattr(engine, "start_server", lambda *a, **k: 8080)
+        monkeypatch.setattr(engine, "_query_server",
+                            lambda *a, **k: [("echo hi", None)])
+
+        def no_fork(*a, **k):
+            raise OSError("cannot fork")
+
+        monkeypatch.setattr(engine.subprocess, "Popen", no_fork)
+        cmds, _, mode = engine.generate("list files",
+                                        {"idle_timeout": 300,
+                                         "host_context": False})
+        assert mode == "server" and cmds == ["echo hi"]
+        assert killed == [signal.SIGTERM]

--- a/whatisit_pkg/tests/test_watchdog.py
+++ b/whatisit_pkg/tests/test_watchdog.py
@@ -1,5 +1,5 @@
 """Tests for whatisit.watchdog: the user-space idle timeout that keeps
-llama-server's CVE-2026-43632-triggering --sleep-idle-seconds flag out of the
+llama-server's CVE-2026-43631-triggering --sleep-idle-seconds flag out of the
 picture entirely.
 
 Hermetic throughout: the poll loop runs against a tmp_path state dir with an
@@ -7,6 +7,7 @@ injectable clock, a recording stop_fn, and a sleep_fn that returns
 immediately. No test spawns a real detached process or waits on wall time.
 """
 import os
+import sys
 import time
 
 import pytest
@@ -88,10 +89,10 @@ class TestRun:
         wd.run(state_dir=sd, now_fn=lambda: NOW,
                sleep_fn=sleeps.append, stop_fn=lambda: stopped.append(1),
                max_ticks=5)
-        # Assert BOTH: no stop AND the loop never even ticked once. A plain
-        # stopped==[] would pass even if the pid guard regressed away --
-        # run() swallows exceptions, so sentinel raises cannot be used here.
-        assert stopped == [] and sleeps == []
+        # Assert BOTH: no stop AND the loop gave up inside the restart grace
+        # instead of running to max_ticks. A plain stopped==[] would pass even
+        # with the guard gone -- run() swallows exceptions, so no sentinel.
+        assert stopped == [] and sleeps == [wd._RETRY] * (wd._GONE_TICKS - 1)
 
     @pytest.mark.parametrize("timeout", [None, 0, -3])
     def test_exits_when_instructions_are_retracted(self, tmp_path, timeout):
@@ -103,25 +104,75 @@ class TestRun:
         wd.run(state_dir=sd, now_fn=lambda: NOW,
                sleep_fn=sleeps.append, stop_fn=lambda: stopped.append(1),
                max_ticks=5)
-        assert stopped == [] and sleeps == []
+        assert stopped == [] and sleeps == [wd._RETRY] * (wd._GONE_TICKS - 1)
 
-    def test_stands_down_when_the_server_was_replaced(self, tmp_path):
-        # A restart changes server.pid; a watchdog attached to the old value
-        # must exit instead of killing across generations.
+    def test_follows_the_server_across_a_restart(self, tmp_path):
+        # We hold the singleton lock, so the restart's own spawn already gave
+        # up. Exiting here would leave the new server with nothing watching.
         sd = make_sd(tmp_path)
-        seed(sd, pid=1, age=10.0, timeout=50)
-        replaced = []
+        seed(sd, pid=1, age=100.0, timeout=50)
+        stopped = []
 
-        def first_nap_replaces_the_server(seconds):
-            if not replaced:
-                replaced.append(1)
-                (sd / "server.pid").write_text("999999\n")
+        def nap_replaces_the_server(seconds):
+            (sd / "server.pid").write_text("222\n")
 
+        wd.run(state_dir=sd, now_fn=lambda: NOW,
+               sleep_fn=nap_replaces_the_server,
+               stop_fn=lambda: stopped.append(
+                   (sd / "server.pid").read_text().strip()),
+               max_ticks=5)
+        assert stopped == ["222"]
+
+    def test_waits_out_a_gap_in_the_pid_file(self, tmp_path):
+        # stop_server unlinks server.pid before start_server writes the new
+        # one. Standing down in that window is what stranded the replacement.
+        sd = make_sd(tmp_path)
+        seed(sd, pid=1, age=100.0, timeout=50)
+        (sd / "server.pid").unlink()
+        stopped = []
+
+        def nap_starts_the_server(seconds):
+            (sd / "server.pid").write_text("222\n")
+
+        wd.run(state_dir=sd, now_fn=lambda: NOW,
+               sleep_fn=nap_starts_the_server,
+               stop_fn=lambda: stopped.append(
+                   (sd / "server.pid").read_text().strip()),
+               max_ticks=5)
+        assert stopped == ["222"]
+
+    def test_does_not_fire_on_a_pid_that_moved_during_the_grace_nap(
+            self, tmp_path):
+        # The pid we decided about is not the pid that is there now.
+        sd = make_sd(tmp_path)
+        seed(sd, pid=1, age=100.0, timeout=50)
         stopped = []
         wd.run(state_dir=sd, now_fn=lambda: NOW,
-               sleep_fn=first_nap_replaces_the_server,
-               stop_fn=lambda: stopped.append(1), max_ticks=5)
+               sleep_fn=lambda s: (sd / "server.pid").write_text("222\n"),
+               stop_fn=lambda: stopped.append(1), max_ticks=1)
         assert stopped == []
+
+    @pytest.mark.parametrize("age,fires", [(49.0, False), (51.0, True)])
+    def test_fires_only_past_the_deadline(self, tmp_path, age, fires):
+        sd = make_sd(tmp_path)
+        seed(sd, age=age, timeout=50)
+        stopped = []
+        wd.run(state_dir=sd, now_fn=lambda: NOW, sleep_fn=lambda s: None,
+               stop_fn=lambda: stopped.append(1), max_ticks=3)
+        assert bool(stopped) is fires
+
+    def test_unloads_a_server_that_was_never_queried(self, tmp_path):
+        # No last_use at all: age from our own start rather than polling for
+        # a timestamp that may never arrive.
+        sd = make_sd(tmp_path)
+        seed(sd, age=0.0, timeout=50)
+        (sd / "server.last_use").unlink()
+        clock = [NOW]
+        stopped = []
+        wd.run(state_dir=sd, now_fn=lambda: clock[0],
+               sleep_fn=lambda s: clock.__setitem__(0, clock[0] + s),
+               stop_fn=lambda: stopped.append(1), max_ticks=50)
+        assert stopped == [1]
 
     def test_grace_reread_cancels_kill_of_a_query_in_flight(self, tmp_path):
         # A query touched last_use between our staleness read and the grace
@@ -159,6 +210,29 @@ class TestRun:
                 os.lseek(fd, 0, os.SEEK_SET)     # unlock needs the locked pos
                 msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
             os.close(fd)
+
+    def test_try_lock_stands_down_when_neither_primitive_exists(
+            self, monkeypatch, tmp_path):
+        # Exercises the msvcrt fallback selection off Windows. With no locking
+        # primitive at all, duplicate watchdogs would be possible, so the only
+        # safe answer is to refuse the lock rather than take it unguarded.
+        sd = make_sd(tmp_path)
+        monkeypatch.setitem(sys.modules, "fcntl", None)
+        monkeypatch.setitem(sys.modules, "msvcrt", None)
+        assert wd._try_lock(sd / "watchdog.lock") is None
+
+    def test_run_swallows_a_failing_stop(self, tmp_path):
+        # run() is the top of a detached process with stderr at /dev/null;
+        # letting anything escape would be an invisible crash that leaves the
+        # lock released and nothing watching.
+        sd = make_sd(tmp_path)
+        seed(sd, age=100.0, timeout=50)
+
+        def boom():
+            raise RuntimeError("stop failed")
+
+        wd.run(state_dir=sd, now_fn=lambda: NOW, sleep_fn=lambda s: None,
+               stop_fn=boom, max_ticks=5)
 
     def test_never_raises_on_a_hostile_state_dir(self, tmp_path):
         sd = make_sd(tmp_path)

--- a/whatisit_pkg/tests/test_watchdog.py
+++ b/whatisit_pkg/tests/test_watchdog.py
@@ -1,0 +1,176 @@
+"""Tests for whatisit.watchdog: the user-space idle timeout that keeps
+llama-server's CVE-2026-43632-triggering --sleep-idle-seconds flag out of the
+picture entirely.
+
+Hermetic throughout: the poll loop runs against a tmp_path state dir with an
+injectable clock, a recording stop_fn, and a sleep_fn that returns
+immediately. No test spawns a real detached process or waits on wall time.
+"""
+import os
+import time
+
+import pytest
+
+from whatisit import watchdog as wd
+
+NOW = 1_000_000.0
+
+
+def make_sd(tmp_path):
+    sd = tmp_path / "run"
+    sd.mkdir(parents=True)
+    return sd
+
+
+def seed(sd, *, pid=4242, timeout=50, age=None):
+    """A consistent-looking state dir; None omits the file."""
+    if pid is not None:
+        (sd / "server.pid").write_text(f"{pid}\n")
+    if timeout is not None:
+        (sd / "server.watch").write_text(f"{timeout}\n")
+    if age is not None:
+        (sd / "server.last_use").write_text(f"{NOW - age:.6f}\n")
+
+
+class TestReadHelpers:
+    def test_read_int(self, tmp_path):
+        p = tmp_path / "f"
+        p.write_text("300\n")
+        assert wd._read_int(p) == 300
+
+    @pytest.mark.parametrize("content", ["junk", "", "tomorrow"])
+    def test_read_int_rejects_garbage(self, tmp_path, content):
+        p = tmp_path / "f"
+        p.write_text(content)
+        assert wd._read_int(p) is None
+
+    def test_read_int_missing_file(self, tmp_path):
+        assert wd._read_int(tmp_path / "absent") is None
+
+    def test_read_ts_valid(self, tmp_path):
+        p = tmp_path / "f"
+        p.write_text(f"{NOW:.6f}\n")
+        assert wd._read_ts(p) == pytest.approx(NOW)
+
+    @pytest.mark.parametrize("content", ["junk", "", "nan", "inf", "-inf"])
+    def test_read_ts_rejects_garbage_and_non_finite(self, tmp_path, content):
+        # nan would silently disarm every deadline comparison; inf would fire
+        # instantly. Both must read as "no timestamp".
+        p = tmp_path / "f"
+        p.write_text(content)
+        assert wd._read_ts(p) is None
+
+
+class TestRun:
+    def test_stops_a_stale_server_exactly_once(self, tmp_path):
+        sd = make_sd(tmp_path)
+        seed(sd, age=100.0, timeout=50)          # idle far past the deadline
+        sleeps, stopped = [], []
+        wd.run(state_dir=sd, now_fn=lambda: NOW,
+               sleep_fn=sleeps.append, stop_fn=lambda: stopped.append(1))
+        assert stopped == [1]
+        assert 0.2 in sleeps                     # the grace re-read happened
+
+    def test_spares_a_fresh_server(self, tmp_path):
+        sd = make_sd(tmp_path)
+        seed(sd, age=10.0, timeout=50)
+        sleeps, stopped = [], []
+        wd.run(state_dir=sd, now_fn=lambda: NOW,
+               sleep_fn=sleeps.append, stop_fn=lambda: stopped.append(1),
+               max_ticks=3)
+        assert stopped == []
+        assert sleeps and all(s > 0 for s in sleeps)
+
+    def test_exits_when_the_server_was_stopped(self, tmp_path):
+        sd = make_sd(tmp_path)
+        seed(sd, pid=None, age=100.0, timeout=50)
+        stopped, sleeps = [], []
+        wd.run(state_dir=sd, now_fn=lambda: NOW,
+               sleep_fn=sleeps.append, stop_fn=lambda: stopped.append(1),
+               max_ticks=5)
+        # Assert BOTH: no stop AND the loop never even ticked once. A plain
+        # stopped==[] would pass even if the pid guard regressed away --
+        # run() swallows exceptions, so sentinel raises cannot be used here.
+        assert stopped == [] and sleeps == []
+
+    @pytest.mark.parametrize("timeout", [None, 0, -3])
+    def test_exits_when_instructions_are_retracted(self, tmp_path, timeout):
+        # Feature turned off mid-flight: a live watchdog must stand down
+        # rather than fire with a deadline from an earlier window.
+        sd = make_sd(tmp_path)
+        seed(sd, timeout=timeout, age=100.0)
+        stopped, sleeps = [], []
+        wd.run(state_dir=sd, now_fn=lambda: NOW,
+               sleep_fn=sleeps.append, stop_fn=lambda: stopped.append(1),
+               max_ticks=5)
+        assert stopped == [] and sleeps == []
+
+    def test_stands_down_when_the_server_was_replaced(self, tmp_path):
+        # A restart changes server.pid; a watchdog attached to the old value
+        # must exit instead of killing across generations.
+        sd = make_sd(tmp_path)
+        seed(sd, pid=1, age=10.0, timeout=50)
+        replaced = []
+
+        def first_nap_replaces_the_server(seconds):
+            if not replaced:
+                replaced.append(1)
+                (sd / "server.pid").write_text("999999\n")
+
+        stopped = []
+        wd.run(state_dir=sd, now_fn=lambda: NOW,
+               sleep_fn=first_nap_replaces_the_server,
+               stop_fn=lambda: stopped.append(1), max_ticks=5)
+        assert stopped == []
+
+    def test_grace_reread_cancels_kill_of_a_query_in_flight(self, tmp_path):
+        # A query touched last_use between our staleness read and the grace
+        # re-read: the toucher also spawned a fresher watchdog, so we exit
+        # without stopping anything.
+        sd = make_sd(tmp_path)
+        seed(sd, age=100.0, timeout=50)
+        stopped = []
+
+        def grace_touches(seconds):
+            if seconds == 0.2:                   # the grace sleep only
+                (sd / "server.last_use").write_text(f"{time.time():.6f}\n")
+
+        wd.run(state_dir=sd, now_fn=time.time, sleep_fn=grace_touches,
+               stop_fn=lambda: stopped.append(1), max_ticks=4)
+        assert stopped == []
+
+    def test_lock_held_elsewhere_means_stand_down(self, tmp_path):
+        sd = make_sd(tmp_path)
+        seed(sd, age=100.0, timeout=50)
+        fd = wd._try_lock(sd / "watchdog.lock")
+        assert fd is not None                    # we are the other singleton
+        try:
+            sleeps, stopped = [], []
+            wd.run(state_dir=sd, now_fn=lambda: NOW,
+                   sleep_fn=sleeps.append,
+                   stop_fn=lambda: stopped.append(1), max_ticks=5)
+            assert stopped == [] and sleeps == []
+        finally:
+            try:
+                import fcntl
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except ImportError:
+                import msvcrt
+                os.lseek(fd, 0, os.SEEK_SET)     # unlock needs the locked pos
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            os.close(fd)
+
+    def test_never_raises_on_a_hostile_state_dir(self, tmp_path):
+        sd = make_sd(tmp_path)
+        (sd / "server.pid").write_text("not-a-pid\n")
+        (sd / "server.watch").write_text("\x00\xff\n")
+        wd.run(state_dir=sd, now_fn=lambda: "not a number",
+               sleep_fn=lambda s: None, stop_fn=lambda: None, max_ticks=2)
+
+
+class TestMainEntryPoint:
+    def test_main_is_a_bare_call_into_run(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(wd, "run", lambda *a, **k: calls.append((a, k)))
+        assert wd.main() is None
+        assert calls == [((), {})]          # no args: state resolved inside

--- a/whatisit_pkg/whatisit/cli.py
+++ b/whatisit_pkg/whatisit/cli.py
@@ -157,6 +157,8 @@ def cmd_query(args, cfg: dict) -> int:
         cfg["server_port"] = args.port
     if args.ctx_size is not None:
         cfg["ctx_size"] = args.ctx_size
+    if args.idle_timeout is not None:
+        cfg["idle_timeout"] = args.idle_timeout
     if args.host_context is not None:
         cfg["host_context"] = args.host_context
     if args.grammar is not None:
@@ -739,6 +741,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="override saved thread count for this invocation")
     ap.add_argument("--ctx-size", type=int, metavar="N",
                     help="override the saved context size for this invocation")
+    ap.add_argument("--idle-timeout", type=int, metavar="SECONDS",
+                    help="stop the resident server after SECONDS of inactivity (0 = never)")
     ap.add_argument("--model", metavar="PATH",
                     help="override the registered model for this invocation")
     ap.add_argument("--host-context", dest="host_context", action="store_true",
@@ -784,7 +788,8 @@ _FLAGS_NOARG = {"-e", "--execute", "-q", "--quiet", "-t", "--timing", "--oneshot
                 "--host-context", "--no-host-context",
                 "--grammar", "--no-grammar", "--debug", "-y", "--yes"}
 _FLAGS_ARG = {"-n", "--num"}
-_FLAGS_QUERY_ARG = {"--port", "--threads", "--ctx-size", "--model"}
+_FLAGS_QUERY_ARG = {"--port", "--threads", "--ctx-size", "--model",
+                    "--idle-timeout"}
 
 
 class QueryArgs:
@@ -805,6 +810,7 @@ class QueryArgs:
         self.num, self.execute, self.quiet = 1, False, False
         self.timing, self.oneshot = False, False
         self.port, self.threads, self.ctx_size, self.model = None, None, None, None
+        self.idle_timeout = None
         self.host_context, self.grammar, self.debug, self.yes = None, None, False, False
         i = 0
         while i < len(argv):
@@ -850,6 +856,10 @@ class QueryArgs:
                     self.ctx_size = int(val)
                     if self.ctx_size <= 0:
                         raise ValueError(f"--ctx-size must be > 0, got {self.ctx_size}")
+                elif a == "--idle-timeout":
+                    self.idle_timeout = int(val)
+                    if self.idle_timeout < 0:
+                        raise ValueError(f"--idle-timeout must be >= 0, got {self.idle_timeout}")
                 else:
                     self.model = val
                 i += 1

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -113,7 +113,7 @@ DEFAULTS = {
     # 0 => never auto-unload. When > 0, a detached watchdog stops the resident
     # server after this many idle seconds, freeing its RAM without waiting for
     # the next query. See engine.touch_last_use() and watchdog.py.
-    # Never passed to llama-server itself (CVE-2026-43632 in builds b7492-b9060
+    # Never passed to llama-server itself (CVE-2026-43631 in builds b7492-b9060
     # is triggered by its native --sleep-idle-seconds flag).
     "idle_timeout": 0,
 }

--- a/whatisit_pkg/whatisit/config.py
+++ b/whatisit_pkg/whatisit/config.py
@@ -110,6 +110,12 @@ DEFAULTS = {
     "force_tcp": False,
     "server_port": None,       # fixed TCP port for the resident server
     "ctx_size": 2048,          # context size passed to llama-server/llama-cli
+    # 0 => never auto-unload. When > 0, a detached watchdog stops the resident
+    # server after this many idle seconds, freeing its RAM without waiting for
+    # the next query. See engine.touch_last_use() and watchdog.py.
+    # Never passed to llama-server itself (CVE-2026-43632 in builds b7492-b9060
+    # is triggered by its native --sleep-idle-seconds flag).
+    "idle_timeout": 0,
 }
 
 

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -343,12 +343,15 @@ def _spawn_watchdog() -> None:
     """Spawn the detached singleton watchdog, best-effort."""
     try:
         kwargs = {}
-        if os.name == "nt":
+        if _is_windows():
             kwargs["creationflags"] = (subprocess.DETACHED_PROCESS
                                        | subprocess.CREATE_NEW_PROCESS_GROUP)
         else:
             kwargs["start_new_session"] = True
+        # cwd: -m puts it first on sys.path, so running from a directory
+        # holding a whatisit/ package would import that one instead.
         subprocess.Popen([sys.executable, "-m", "whatisit.watchdog"],
+                         cwd=str(_state_dir()),
                          stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
                          stderr=subprocess.DEVNULL, close_fds=True, **kwargs)
     except OSError:
@@ -359,8 +362,9 @@ def idle_stop(idle_timeout) -> bool:
     """Stop a resident server that has been idle past its deadline.
 
     Fallback for when the watchdog cannot run (spawn failed, platform without
-    flock, etc.). The watchdog is the primary mechanism; this lazy check is
-    belt-and-suspenders and mirrors the watchdog's decision logic.
+    flock, etc.). Narrower than the watchdog on purpose: with no recorded
+    last_use there is nothing to age from here, so a launched-but-never-queried
+    server is left to the watchdog, which anchors on its own start instead.
     """
     timeout = _coerce_idle_timeout(idle_timeout)
     if timeout is None:
@@ -377,7 +381,7 @@ def idle_stop(idle_timeout) -> bool:
         return False
     if time.time() - last < timeout:
         return False
-    return stop_server()
+    return bool(stop_server())
 
 
 def _free_port() -> int:
@@ -669,10 +673,12 @@ def _pid_gone(pid: int) -> bool:
 
 
 def _reap(pid: int) -> None:
-    """Clear the zombie if this server happens to be our own child.
+    """Clear the zombie when the server is this process's own child.
 
-    A dead-but-unreaped process still answers signal 0, so without this the
-    escalation below would never see it exit.
+    Never true on the CLI paths, where stop_server runs in a fresh process or
+    in the watchdog: it applies to the in-process restart in start_server, and
+    to the tests. A dead-but-unreaped child still answers signal 0, so without
+    this the escalation below burns the whole window and still reports failure.
     """
     try:
         os.waitpid(pid, os.WNOHANG)
@@ -691,7 +697,9 @@ def _terminate(pid: int) -> bool:
     except (ProcessLookupError, PermissionError):
         return False
     if _is_windows():
-        return True              # TerminateProcess; nothing to escalate to
+        # TerminateProcess; nothing to escalate to. This return is also what
+        # keeps _pid_gone's own nt guard unreached from here.
+        return True
     deadline = time.monotonic() + _STOP_WAIT
     while True:
         _reap(pid)

--- a/whatisit_pkg/whatisit/engine.py
+++ b/whatisit_pkg/whatisit/engine.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import math
 import os
 import re
 import secrets
@@ -31,10 +32,12 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from contextlib import contextmanager
 from pathlib import Path
 
 from . import config as cfg_mod
@@ -210,6 +213,171 @@ def _port_file() -> Path:
 
 def _params_file() -> Path:
     return _state_dir() / "server.params"
+
+
+def _last_use_path() -> Path:
+    return _state_dir() / "server.last_use"
+
+
+def _watch_path() -> Path:
+    # Watchdog instructions: just the deadline, re-read every tick, so
+    # changing --idle-timeout reaches a live watchdog without a restart.
+    return _state_dir() / "server.watch"
+
+
+def _coerce_idle_timeout(v) -> int | None:
+    """Coerce persisted idle_timeout to int, or None if disabled/invalid.
+
+    Invalid persisted values (e.g. ``"tomorrow"``) must not crash queries.
+    """
+    if v is None:
+        return None
+    try:
+        iv = int(v)
+    except (TypeError, ValueError):
+        return None
+    if iv <= 0:
+        return None
+    return iv
+
+
+def touch_last_use(idle_timeout) -> None:
+    """Record now as the server's last use, but only when idle timeout is on.
+
+    Called before and after a successful server-mode query. When the feature
+    is off (idle_timeout <= 0 or invalid) nothing is written, so the file
+    never exists and the idle checks are no-ops.
+    """
+    if _coerce_idle_timeout(idle_timeout) is None:
+        return
+    _touch_now()
+
+
+def _touch_now() -> None:
+    """Atomically publish the activity timestamp.
+
+    Truncate-then-write leaves a window where readers (watchdog tick,
+    idle_stop, this very heartbeat racing a query) see an EMPTY file -- a
+    torn read that reads as 'no data' or, at the worst moment, makes the
+    watchdog's grace reread fall through and kill a freshly-refreshed
+    server. Write to a unique temp sibling and rename: os.replace publishes
+    the new content in one step, and replacing a planted symlink swaps the
+    link rather than following it.
+    """
+    p = _last_use_path()
+    tmp = p.with_name(f".{p.name}.{os.getpid()}.{secrets.token_hex(4)}")
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if os.name != "nt":
+            flags |= os.O_NOFOLLOW
+        fd = os.open(str(tmp), flags, 0o600)
+        try:
+            os.fchmod(fd, 0o600)
+        except (OSError, AttributeError):
+            pass
+        with os.fdopen(fd, "w") as f:
+            f.write(f"{time.time():.6f}\n")
+        os.replace(str(tmp), str(p))
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass  # a missing timestamp only means the model stays loaded longer
+
+
+@contextmanager
+def _heartbeat(idle_timeout):
+    """Refresh last_use while one inference runs.
+
+    The pre-query touch alone cannot protect an inference that outlives
+    idle_timeout: nothing updates the timestamp while _query_server blocks,
+    so a 45 s generation under --idle-timeout 30 would look idle and get
+    stopped at t=30. A daemon thread re-arms the deadline every quarter of
+    the timeout until the query returns.
+    """
+    if idle_timeout is None:
+        yield
+        return
+    interval = max(0.05, min(float(idle_timeout) / 4.0, 10.0))
+    stop = threading.Event()
+
+    def beat():
+        while not stop.wait(interval):
+            _touch_now()
+
+    t = threading.Thread(target=beat, daemon=True)
+    t.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        t.join(timeout=2.0)
+
+
+def _write_watch_file(idle_timeout: int) -> None:
+    """Publish the deadline for the watchdog; see _watch_path()."""
+    try:
+        _write_private(_watch_path(), f"{int(idle_timeout)}\n")
+    except OSError:
+        pass
+
+
+def _clear_watch_state() -> None:
+    """Retract watchdog instructions and stale activity marks.
+
+    Runs when idle timeout is off: a live watchdog from an earlier
+    --idle-timeout window must exit rather than keep killing servers with the
+    deadline that was current when it spawned. Deliberately does NOT create
+    the state dir -- unlink(missing_ok=True) needs no parent, and this path
+    must stay free of filesystem side effects (sandboxed CI has no HOME).
+    """
+    run_dir = cfg_mod.data_dir() / "run"
+    for name in ("server.watch", "server.last_use"):
+        try:
+            (run_dir / name).unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _spawn_watchdog() -> None:
+    """Spawn the detached singleton watchdog, best-effort."""
+    try:
+        kwargs = {}
+        if os.name == "nt":
+            kwargs["creationflags"] = (subprocess.DETACHED_PROCESS
+                                       | subprocess.CREATE_NEW_PROCESS_GROUP)
+        else:
+            kwargs["start_new_session"] = True
+        subprocess.Popen([sys.executable, "-m", "whatisit.watchdog"],
+                         stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                         stderr=subprocess.DEVNULL, close_fds=True, **kwargs)
+    except OSError:
+        pass  # spawning must never break the query; lazy idle_stop covers it
+
+
+def idle_stop(idle_timeout) -> bool:
+    """Stop a resident server that has been idle past its deadline.
+
+    Fallback for when the watchdog cannot run (spawn failed, platform without
+    flock, etc.). The watchdog is the primary mechanism; this lazy check is
+    belt-and-suspenders and mirrors the watchdog's decision logic.
+    """
+    timeout = _coerce_idle_timeout(idle_timeout)
+    if timeout is None:
+        return False
+    sd = _state_dir()
+    p = _last_use_path()
+    if not (sd / "server.pid").exists() or not p.exists():
+        return False
+    try:
+        last = float(p.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    if not math.isfinite(last):
+        return False
+    if time.time() - last < timeout:
+        return False
+    return stop_server()
 
 
 def _free_port() -> int:
@@ -573,6 +741,8 @@ def stop_server() -> bool | None:
     _sock_path().unlink(missing_ok=True)
     _token_path().unlink(missing_ok=True)
     _params_file().unlink(missing_ok=True)
+    _last_use_path().unlink(missing_ok=True)
+    _watch_path().unlink(missing_ok=True)
     return stopped
 
 
@@ -1126,10 +1296,29 @@ def generate(prompt: str, cfg: dict, n: int = 1, force_oneshot: bool = False,
 
     t0 = time.time()
     if server_bin is not None:
+        # Lazy fallback: if the watchdog could not run (spawn failed, platform
+        # without flock), this still frees a server idle past the deadline on
+        # the next query.
+        idle_stop(cfg.get("idle_timeout", 0))
         port = start_server(model, server_bin, threads, quiet=quiet,
                             port=cfg.get("server_port"),
                             ctx_size=cfg.get("ctx_size", 2048))
-        raws = _query_server(port, user_msg, cfg, n, system=system, grammar=grammar)
+        it = _coerce_idle_timeout(cfg.get("idle_timeout", 0))
+        if it is None:
+            # Feature off: retract instructions so any live watchdog stands
+            # down instead of firing with a deadline from an earlier window.
+            _clear_watch_state()
+        else:
+            # Pre-query touch matters: an inference longer than the timeout
+            # must not look like idleness and get killed mid-flight.
+            touch_last_use(it)
+            _write_watch_file(it)
+            _spawn_watchdog()
+        with _heartbeat(it):
+            raws = _query_server(port, user_msg, cfg, n, system=system,
+                                 grammar=grammar)
+        if it is not None:
+            touch_last_use(it)
         mode = "server"
     else:
         cli = cfg_mod.find_llama_cli()

--- a/whatisit_pkg/whatisit/watchdog.py
+++ b/whatisit_pkg/whatisit/watchdog.py
@@ -2,11 +2,12 @@
 
 Spawned detached by engine.generate(); llama-server's native
 --sleep-idle-seconds flag is never used (in builds b7492-b9060 it triggers
-CVE-2026-43632). Unlike checking idleness only on the next query, this frees
+CVE-2026-43631). Unlike checking idleness only on the next query, this frees
 the model's RAM at N seconds even when no further query ever arrives.
 
 Contract with engine, all files inside the 0700 state dir:
-  server.pid     written by start_server(); disappearing or CHANGING ends us
+  server.pid     written by start_server(); re-read every tick, so a
+                 restart is followed, not treated as a stop
   server.watch   "<timeout>\\n", rewritten by every server-mode query while
                  the feature is on and removed when it is turned off
   server.last_use  touched before and after each server-mode query
@@ -24,6 +25,8 @@ import time
 from pathlib import Path
 
 _TICK_MAX = 5.0
+_RETRY = 1.0
+_GONE_TICKS = 3
 
 
 def _try_lock(path: Path):
@@ -100,33 +103,33 @@ def run(state_dir=None, now_fn=time.time, sleep_fn=time.sleep, stop_fn=None,
 def _loop(sd: Path, now_fn, sleep_fn, stop_fn, max_ticks) -> None:
     pid_f, watch_f, use_f = (sd / "server.pid", sd / "server.watch",
                              sd / "server.last_use")
-    pid = _read_int(pid_f)
-    if pid is None:
-        return
-    ticks = 0
+    started = now_fn()
+    ticks = gone = 0
     while max_ticks is None or ticks < max_ticks:
         ticks += 1
-        # Superseded (restart/model switch) or stopped: whatever watches now
-        # must attach to the CURRENT pid, not fire across generations.
-        if _read_int(pid_f) != pid:
-            return
-        timeout = _read_int(watch_f)
-        if timeout is None or timeout <= 0:
-            return                   # feature off, instructions retracted
-        last = _read_ts(use_f)
-        if last is None:             # launched, not yet queried: wait for it
-            sleep_fn(min(_TICK_MAX, max(0.05, timeout / 10)))
+        pid, timeout = _read_int(pid_f), _read_int(watch_f)
+        if pid is None or timeout is None or timeout <= 0:
+            # The sub-second gap where stop_server has unlinked the pid and
+            # start_server has not written the new one. We hold the lock, so a
+            # replacement spawn already gave up: wait rather than leave nothing
+            # watching. A full restart outlives this and is re-armed by the
+            # post-ready _spawn_watchdog().
+            gone += 1
+            if gone >= _GONE_TICKS:
+                return               # really stopped, or feature turned off
+            sleep_fn(_RETRY)
             continue
-        idle = max(0.0, now_fn() - last)
+        gone = 0
+        seen = _read_ts(use_f)
+        # Never queried: age from our own start, so a server that is launched
+        # and then abandoned still gets unloaded.
+        idle = max(0.0, now_fn() - (started if seen is None else seen))
         if idle < timeout:
             sleep_fn(min(timeout - idle, _TICK_MAX))
             continue
-        sleep_fn(0.2)                # grace: a query touching last_use now
-        last = _read_ts(use_f)       # also spawned a fresher watchdog
-        if last is not None and now_fn() - last < timeout:
-            return
-        if _read_int(pid_f) != pid:
-            return
+        sleep_fn(0.2)                # grace: a query may be touching now
+        if _read_ts(use_f) != seen or _read_int(pid_f) != pid:
+            continue                 # busy or superseded: keep watching
         if stop_fn is not None:
             stop_fn()
         else:

--- a/whatisit_pkg/whatisit/watchdog.py
+++ b/whatisit_pkg/whatisit/watchdog.py
@@ -1,0 +1,143 @@
+"""whatisit.watchdog - user-space idle timeout for the resident llama-server.
+
+Spawned detached by engine.generate(); llama-server's native
+--sleep-idle-seconds flag is never used (in builds b7492-b9060 it triggers
+CVE-2026-43632). Unlike checking idleness only on the next query, this frees
+the model's RAM at N seconds even when no further query ever arrives.
+
+Contract with engine, all files inside the 0700 state dir:
+  server.pid     written by start_server(); disappearing or CHANGING ends us
+  server.watch   "<timeout>\\n", rewritten by every server-mode query while
+                 the feature is on and removed when it is turned off
+  server.last_use  touched before and after each server-mode query
+
+A non-blocking flock makes this a singleton: extra spawns (one per query)
+exit immediately, so repeated invocations cost nothing. Everything here is
+best-effort and silent; engine.idle_stop() is the lazy fallback whenever this
+process is not around.
+"""
+from __future__ import annotations
+
+import math
+import os
+import time
+from pathlib import Path
+
+_TICK_MAX = 5.0
+
+
+def _try_lock(path: Path):
+    """fd holding an exclusive non-blocking lock, or None if one is held."""
+    # O_NOFOLLOW, matching engine._write_private: WHATISIT_DATA_DIR is
+    # user-controlled, so a planted symlink must fail loudly, not be locked.
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    try:
+        import fcntl
+    except ImportError:
+        fcntl = None
+    if fcntl is not None:
+        fd = None
+        try:
+            fd = os.open(str(path), os.O_CREAT | os.O_RDWR | nofollow, 0o600)
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except OSError:
+            if fd is not None:
+                os.close(fd)     # flock lost the race: don't leak the fd
+            return None
+    try:
+        import msvcrt
+    except ImportError:              # neither primitive: duplicates would be
+        return None                  # possible, so standing down is safer
+    fd = None
+    try:
+        fd = os.open(str(path), os.O_CREAT | os.O_RDWR | nofollow, 0o600)
+        os.write(fd, b"\0")      # msvcrt locks a byte RANGE, so the file
+        os.lseek(fd, 0, os.SEEK_SET)  # needs >= 1 byte, and every holder
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)  # must contend on offset 0
+        return fd
+    except OSError:
+        if fd is not None:
+            os.close(fd)
+        return None
+
+
+def _read_int(path: Path) -> int | None:
+    try:
+        return int(path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _read_ts(path: Path) -> float | None:
+    try:
+        v = float(path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+    # "nan" would disarm every deadline comparison; "inf" would fire at once.
+    return v if math.isfinite(v) else None
+
+
+def run(state_dir=None, now_fn=time.time, sleep_fn=time.sleep, stop_fn=None,
+        max_ticks=None) -> None:
+    """Watch the state dir until the idle deadline fires; injectable for tests."""
+    try:
+        if state_dir is None:
+            from . import engine
+            state_dir = engine._state_dir()
+        sd = Path(state_dir)
+        fd = _try_lock(sd / "watchdog.lock")
+        if fd is None:
+            return                   # a live singleton already watches this
+        try:
+            _loop(sd, now_fn, sleep_fn, stop_fn, max_ticks)
+        finally:
+            os.close(fd)
+    except Exception:
+        pass                         # never surface anything to the user
+
+
+def _loop(sd: Path, now_fn, sleep_fn, stop_fn, max_ticks) -> None:
+    pid_f, watch_f, use_f = (sd / "server.pid", sd / "server.watch",
+                             sd / "server.last_use")
+    pid = _read_int(pid_f)
+    if pid is None:
+        return
+    ticks = 0
+    while max_ticks is None or ticks < max_ticks:
+        ticks += 1
+        # Superseded (restart/model switch) or stopped: whatever watches now
+        # must attach to the CURRENT pid, not fire across generations.
+        if _read_int(pid_f) != pid:
+            return
+        timeout = _read_int(watch_f)
+        if timeout is None or timeout <= 0:
+            return                   # feature off, instructions retracted
+        last = _read_ts(use_f)
+        if last is None:             # launched, not yet queried: wait for it
+            sleep_fn(min(_TICK_MAX, max(0.05, timeout / 10)))
+            continue
+        idle = max(0.0, now_fn() - last)
+        if idle < timeout:
+            sleep_fn(min(timeout - idle, _TICK_MAX))
+            continue
+        sleep_fn(0.2)                # grace: a query touching last_use now
+        last = _read_ts(use_f)       # also spawned a fresher watchdog
+        if last is not None and now_fn() - last < timeout:
+            return
+        if _read_int(pid_f) != pid:
+            return
+        if stop_fn is not None:
+            stop_fn()
+        else:
+            from . import engine
+            engine.stop_server()
+        return
+
+
+def main() -> None:
+    run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #42.

The feature is @lydorianP's work from #44. His two commits are carried here
unchanged and authored to him; the third commit is review follow-up.

### What it does

`whatisit --idle-timeout 300`, or `whatisit config --set idle_timeout=300` to
persist it, lets the resident model unload itself after five minutes of
inactivity instead of holding memory indefinitely. Off by default. The next
query pays a cold start.

llama.cpp has its own `--sleep-idle-seconds` flag for this. It is deliberately
not used: in builds b7492-b9060 that flag triggers CVE-2026-43631. This is a
small user-space watchdog that polls a timestamp file instead, and a test pins
that the flag is never passed to the server.

### Review follow-up

The third commit fixes issues found reviewing #44. The significant one: the
watchdog stopped working after any server restart. It recorded the process id
once at startup and exited when it changed, but it also holds a lock that turns
away any replacement, so after a restart nothing was watching and the model
stayed resident. It now re-reads the id each tick.

Also in that commit: the test covering the above did not actually exercise it,
a missing timestamp could make the watchdog loop forever, the detached process
inherited the working directory in a way that could change which package it
imported, and the CVE identifier was wrong.

Stacked on #51.